### PR TITLE
修复连接达梦数据库报错,驱动包版本信息sqlalchemy:2.0.48,dmsqlalchemy:2.0.11，dmpython:2.5.30

### DIFF
--- a/config.py
+++ b/config.py
@@ -57,7 +57,7 @@ class DatabaseConfig:
             # Oracle 使用 service_name 格式
             return f"oracle+oracledb://{encoded_user}:{encoded_password}@{self.host}:{self.port}/?service_name={self.database}"
         elif self.type == "dameng":
-            return f"dm+dmPython://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{self.database}"
+            return f"dm+dmPython://{encoded_user}:{encoded_password}@{self.host}:{self.port}"
         elif self.type == "doris":
             return f"doris+mysql://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{self.database}"
         else:

--- a/service/schema_builder.py
+++ b/service/schema_builder.py
@@ -77,7 +77,8 @@ class SchemaRAGBuilder:
         elif db_type == "oracle":
             engine_args["connect_args"] = {"thick_mode": False}
         elif db_type == "dameng":
-            engine_args["connect_args"] = {"encoding": "UTF-8"}
+            schema = self.db_config.database
+            engine_args["connect_args"] = {'schema': schema}
         elif db_type == "postgresql":
             # PostgreSQL 使用 psycopg2，默认支持 UTF-8
             pass


### PR DESCRIPTION
- 修复连接时提示不支持'database'参数
- 修复连接时提示不支持'encoding'参数
修复设置API KEY授权配置时出现“配置验证或构建过程中发生错误: 无法初始化Schema引擎，请检查数据库配置”的问题