### PR TITLE
fix：oracledb 更新导致了thick_mode参数不在connect参数列表中，导致oracle连接报错

### DIFF
--- a/service/schema_builder.py
+++ b/service/schema_builder.py
@@ -75,7 +75,7 @@ class SchemaRAGBuilder:
             # SQL Server (pymssql) 配置：charset 使用小写 utf8
             engine_args["connect_args"] = {"charset": "utf8"}
         elif db_type == "oracle":
-            engine_args["connect_args"] = {"thick_mode": False}
+            engine_args["connect_args"] = {"thick_mode_dsn_passthrough": False}
         elif db_type == "dameng":
             engine_args["connect_args"] = {"encoding": "UTF-8"}
         elif db_type == "postgresql":


### PR DESCRIPTION
更新oracle连接参数，之前更新过一部分，后来发现在特定情况下会走到SchemaRAGBuilder里面关于oracle的连接参数也需更新
