### PR TITLE
[codex] 修复插件授权校验和知识库上传问题

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,495 @@
+# AGENTS.md - AI Assistant Guide for SchemaRAG Dify Plugin
+
+This file is the operating guide for AI agents working in this repository. Follow it together with the user's latest request and the repository's existing code style.
+
+## Project Overview
+
+SchemaRAG is a **Dify tool provider plugin** that automates database schema extraction, uploads schema dictionaries to Dify Knowledge Bases, and provides natural-language-to-SQL tools for Dify Chatflow / Workflow / Agent applications.
+
+- **Type:** Dify Tool Provider Plugin
+- **Version:** 0.1.7
+- **Runtime:** Python 3.12+ in Dify plugin runner
+- **License:** Apache-2.0
+- **Author:** joto (JOTO-AI)
+
+### Core Functionality
+
+- Multi-database schema extraction and indexing
+- Schema dictionary upload to Dify Knowledge Bases
+- Natural language to SQL conversion
+- SQL execution with safety controls
+- LLM-based data analysis and visualization
+- SQL auto-repair with LLM feedback
+
+## Official Dify References
+
+When changing plugin behavior, validate assumptions against the current official Dify docs first:
+
+- Tool plugin development: <https://docs.dify.ai/en/develop-plugin/dev-guides-and-walkthroughs/tool-plugin>
+- Manifest specification: <https://docs.dify.ai/en/develop-plugin/features-and-specs/plugin-types/plugin-info-by-manifest>
+- List Knowledge Bases: <https://docs.dify.ai/api-reference/datasets/get-knowledge-base-list>
+- Create Knowledge Base: <https://docs.dify.ai/api-reference/knowledge-bases/create-an-empty-knowledge-base>
+- Create Document by Text: <https://docs.dify.ai/api-reference/documents/create-document-by-text>
+- Create Document by File: <https://docs.dify.ai/api-reference/documents/create-document-by-file>
+
+Important current API facts:
+
+- Knowledge Base list endpoint is `GET /datasets`, with paginated response fields such as `data`, `has_more`, `limit`, and `total`.
+- Knowledge Base creation endpoint is `POST /datasets`; duplicate names can return HTTP 409.
+- Document upload endpoints use hyphenated paths:
+  - `POST /datasets/{dataset_id}/document/create-by-text`
+  - `POST /datasets/{dataset_id}/document/create-by-file`
+- Knowledge Base API requests require `Authorization: Bearer {API_KEY}`.
+
+## Repository Structure
+
+```
+SchemaRAG-dify-plugin/
+├── core/
+│   ├── dify/                   # Low-level Dify HTTP clients
+│   ├── llm_plot/               # Chart generation and data analysis helpers
+│   └── m_schema/               # Schema metadata extraction and representation
+├── service/
+│   ├── cache/                  # LRU / TTL cache implementations
+│   ├── context/                # Conversation memory
+│   ├── database_service.py     # SQLAlchemy execution layer
+│   ├── dify_service.py         # Dify Knowledge Base upload workflow
+│   ├── knowledge_service.py    # Knowledge Base retrieval
+│   ├── schema_builder.py       # Schema dictionary generation and upload
+│   └── sql_refiner.py          # SQL auto-repair
+├── tools/                      # Dify tool implementations and YAML descriptors
+├── provider/                   # Tool provider YAML and credential validation
+├── prompt/                     # Prompt templates
+├── test/                       # pytest / unittest tests
+├── docs/                       # Project docs
+├── manifest.yaml               # Dify plugin manifest
+├── main.py                     # Dify plugin entry point
+├── pyproject.toml              # Python package metadata
+├── requirements.txt            # Plugin/package requirements fallback
+└── uv.lock                     # Locked dependencies
+```
+
+## Agent Operating Rules
+
+- Inspect `git status --short` before editing. This workspace may contain unrelated user changes.
+- Never revert, overwrite, stage, commit, or format unrelated changes unless the user explicitly asks.
+- Never commit secrets. In particular, `.env`, `.env.example`, remote install keys, database passwords, and dataset API keys must not be committed.
+- Prefer narrow, behavior-focused changes. Do not bundle release version bumps, README rewrites, or manifest edits into bugfix PRs unless requested.
+- Use `rg` / `rg --files` for searching.
+- Use `apply_patch` for manual file edits.
+- Keep comments and logs primarily in Chinese, matching the existing codebase.
+- Preserve Dify plugin compatibility before making convenience refactors.
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.12+
+- `uv`
+- A Dify instance and plugin debug key for remote debugging
+
+### Local Commands
+
+```bash
+# Install / sync dependencies
+uv sync
+
+# Run the plugin for remote debugging
+uv run main.py
+
+# Run focused tests
+uv run --no-sync pytest test/test_dify_client.py test/test_dify_service.py
+```
+
+Use `uv run --no-sync` for focused tests after dependencies are already installed. This avoids unnecessary dependency resolution while working on code.
+
+### Debug Configuration
+
+Copy `.env.example` to `.env` and put real debug credentials only in `.env`:
+
+```env
+INSTALL_METHOD=remote
+REMOTE_INSTALL_URL=<plugin-daemon-url>
+REMOTE_INSTALL_KEY=<debug-key-from-dify>
+```
+
+Do not replace placeholders in `.env.example` with real credentials.
+
+## Dify Plugin Rules
+
+### Manifest
+
+`manifest.yaml` must remain YAML-valid. Dify packaging can fail if this file is malformed.
+
+Current plugin permissions are intentional:
+
+- `tool.enabled: true`
+- `model.enabled: true`, `llm: true`
+- `storage.enabled: true`
+- `app.enabled: false`
+
+Only add permissions when a feature truly needs them, and explain why in the PR.
+
+### Provider YAML
+
+`provider/provider.yaml` defines:
+
+- provider identity and labels
+- `credentials_for_provider`
+- supported app types
+- tool YAML registrations
+- Python provider entrypoint under `extra.python`
+
+When adding or changing credentials:
+
+- Use `secret-input` for API keys, passwords, and tokens.
+- Keep labels / descriptions multilingual when nearby fields are multilingual.
+- Keep `tools:` aligned with actual files under `tools/`.
+
+### Provider Credential Validation
+
+`provider/build_schema_rag.py` implements `ToolProvider`.
+
+Rules:
+
+- `_validate_credentials(credentials)` must either return `None` on success or raise `ToolProviderCredentialValidationError` on validation failure.
+- Do not leak passwords, dataset API keys, or debug keys in errors or logs.
+- If validation performs side effects, such as schema generation and upload, every external failure must be converted to `ToolProviderCredentialValidationError`.
+- Keep root-cause information in the message, but avoid sensitive values.
+
+### Tool Implementations
+
+Tools under `tools/*.py` inherit from `dify_plugin.Tool`.
+
+Rules:
+
+- Implement `_invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]`.
+- Yield Dify messages using helpers such as `create_text_message` or `create_json_message`.
+- Validate parameters before calling services.
+- Keep LLM calls inside tool runtime paths, not provider validation.
+- Use `self.runtime.credentials` for provider credentials and never hard-code credentials.
+
+### Tool YAML
+
+Each tool YAML should include:
+
+- `identity`
+- `description.human`
+- `description.llm`
+- `parameters`
+- `form: llm` for LLM-inferred parameters
+- `form: form` for UI-configured parameters
+
+When adding parameters:
+
+- Include `label`, `human_description`, and `llm_description`.
+- Use `select` with explicit `options` for finite modes.
+- Use `model-selector` for model choices.
+- Keep defaults conservative.
+
+## Dify Knowledge Base API Rules
+
+The project uses `core/dify/dify_client.py` and `service/dify_service.py` to create/find Knowledge Bases and upload schema documents.
+
+Rules:
+
+- Use the configured `api_uri` as the base URL, normally ending in `/v1`.
+- Use `Authorization: Bearer <dataset_api_key>`.
+- Use `httpx.Client(timeout=30.0, trust_env=False)` for Dify API calls. This prevents internal Dify hosts such as `192.168.*` from being routed through system proxy variables.
+- When finding a Knowledge Base by name, scan all pages from `GET /datasets`; do not assume the target is on page 1.
+- On `POST /datasets` HTTP 409, retry paginated lookup before reporting failure.
+- Use official hyphenated document endpoints: `create-by-text`, `create-by-file`, `update-by-text`, and `update-by-file`.
+- `create-by-text` and `create-by-file` are asynchronous and return a `batch`; do not assume indexing is complete immediately unless code explicitly checks indexing status.
+- Preserve readable API error messages. Do not wrap known HTTP status errors into vague "unknown error" messages.
+
+## Supported Databases
+
+| Database | Port | Driver | SQLAlchemy URI Format |
+|----------|------|--------|-----------------------|
+| MySQL | 3306 | `pymysql` | `mysql+pymysql://user:pass@host:port/db` |
+| PostgreSQL | 5432 | `psycopg2-binary` | `postgresql+psycopg2://user:pass@host:port/db` |
+| SQL Server | 1433 | `pymssql` | `mssql+pymssql://user:pass@host:port/db` |
+| Oracle | 1521 | `oracledb` | `oracle+oracledb://user:pass@host:port/?service_name=db` |
+| DamengDB | 5236 | `dmPython` + `dmSQLAlchemy` | `dm+dmPython://user:pass@host:port` with schema switch |
+| Doris | 9030 | `pymysql` / Doris dialect | `doris+pymysql://user:pass@host:port/db` |
+
+Database rules:
+
+- URL-encode usernames and passwords in connection strings.
+- Keep database credentials out of logs and cache keys.
+- SQL execution tools must enforce SELECT-only behavior where intended.
+- Result row limits must stay configurable and bounded.
+- Dameng dependencies are platform-limited. `dmpython` and `dmsqlalchemy` must not be mandatory on macOS because wheels are unavailable there.
+- Do not add source-build `psycopg2`; keep `psycopg2-binary` unless there is a deliberate deployment reason and a matching CI change.
+
+## Architecture Boundaries
+
+Follow the existing flow:
+
+```
+Provider -> Tool -> Service -> Database / Dify API
+              |
+              v
+          Validators
+```
+
+Boundary rules:
+
+- `provider/`: credential validation, provider setup, high-level orchestration.
+- `tools/`: Dify tool entrypoints, parameter validation, runtime output.
+- `service/`: business workflows such as schema build, upload, SQL execution, retrieval, and repair.
+- `core/dify/`: low-level Dify HTTP client only.
+- `core/m_schema/`: database schema extraction and metadata representation.
+- `prompt/`: prompt construction only.
+
+Avoid moving HTTP request details into tools or provider code. Avoid placing Dify runtime concerns inside database schema extraction classes.
+
+## Coding Conventions
+
+### Language
+
+- Internal comments, docstrings, and logs are primarily Chinese.
+- Public labels and descriptions should keep existing multilingual style: `en_US`, `zh_Hans`, `pt_BR`, and any existing locales nearby.
+- Error messages shown to users should be actionable and not expose secrets.
+
+### Style
+
+```python
+"""
+项目配置模块
+"""
+
+import os
+from typing import Dict, List, Optional
+
+from sqlalchemy import create_engine
+
+from service.database_service import DatabaseService
+
+
+class MyTool(Tool):
+    DEFAULT_TOP_K = 5
+    MAX_CONTENT_LENGTH = 10000
+    _cache_max_size = 10
+
+    def __init__(self, *args, **kwargs):
+        """初始化工具"""
+        super().__init__(*args, **kwargs)
+```
+
+Rules:
+
+- Use type hints for function parameters and return values.
+- Prefer `Optional`, `Dict`, `List`, and `Tuple` consistently with the existing code.
+- Keep class-level constants in `UPPER_SNAKE_CASE`.
+- Use private method prefixes for internal helpers.
+- Add comments only where they explain non-obvious behavior.
+
+### Logging
+
+```python
+import logging
+from dify_plugin.config.logger_format import plugin_logger_handler
+
+logger = logging.getLogger(__name__)
+logger.addHandler(plugin_logger_handler)
+```
+
+Rules:
+
+- Log important state transitions: schema generation, Dify upload, SQL execution, retries, and cache hits.
+- Never log passwords, API keys, tokens, or full connection strings.
+- Prefer root-cause messages over generic "unknown error".
+
+## Dependency Rules
+
+Maintain dependency declarations in both `pyproject.toml` and `requirements.txt` when applicable.
+
+Current constraints:
+
+- `dify-plugin` is required for plugin runtime.
+- `pymysql`, `psycopg2-binary`, `pymssql`, and `oracledb` support the main database drivers.
+- `dmpython` and `dmsqlalchemy` must use platform markers for Linux/Windows only.
+- `uv.lock` must be refreshed when `pyproject.toml` dependencies change.
+
+After dependency edits, run:
+
+```bash
+uv lock
+uv run --no-sync pytest test/test_dependency_metadata.py
+```
+
+## Testing Guidelines
+
+Tests live under `test/` and currently use `pytest` with many `unittest.TestCase` classes.
+
+### Test Naming
+
+- `test_dify_client.py`: low-level Dify HTTP client behavior and endpoint paths.
+- `test_dify_service.py`: Knowledge Base upload workflow, dataset lookup, pagination, conflict handling.
+- `test_provider_credentials.py`: provider credential validation and Dify SDK error types.
+- `test_dependency_metadata.py`: platform-specific dependency metadata.
+- `test_sql_refiner.py`: SQL repair behavior.
+- `test_context_manager.py`: conversation memory behavior.
+
+### Required Tests by Change Type
+
+| Change Type | Minimum Test Command |
+|-------------|----------------------|
+| Dify HTTP client paths/proxy/errors | `uv run --no-sync pytest test/test_dify_client.py` |
+| Knowledge Base upload / dataset lookup | `uv run --no-sync pytest test/test_dify_service.py` |
+| Provider credential validation | `uv run --no-sync pytest test/test_provider_credentials.py` |
+| Dependency metadata | `uv run --no-sync pytest test/test_dependency_metadata.py` |
+| SQL repair | `uv run --no-sync pytest test/test_sql_refiner.py` |
+| General sanity | `uv run --no-sync pytest test/` |
+
+When fixing a bug, add or update a regression test first when feasible. Run the test red, implement the fix, then run it green.
+
+## Security Considerations
+
+- Do not commit `.env` or real debug credentials.
+- Keep `.env.example` placeholder-only.
+- Use `secret-input` for sensitive provider credentials.
+- Do not print database passwords or dataset API keys.
+- Cache keys must exclude passwords.
+- SQL execution tools must reject dangerous statements when designed as query-only tools.
+- Respect optional table and column whitelists.
+- Treat Dify Dataset API keys as server-side secrets.
+
+## Common Development Tasks
+
+### Adding a New Tool
+
+1. Create `tools/my_tool.py` implementing `Tool`.
+2. Create `tools/my_tool.yaml`.
+3. Register the YAML in `provider/provider.yaml`.
+4. Add or update provider imports only if the provider needs to return the tool class.
+5. Add focused tests under `test/`.
+6. Run the relevant pytest command.
+
+### Adding Database Support
+
+1. Add the driver dependency with platform markers if the package is not universal.
+2. Add mapping in `DatabaseService.DB_DRIVERS`.
+3. Add connection string logic in `config.py`.
+4. Add SQLAlchemy engine args if required.
+5. Update `provider/provider.yaml` database type options.
+6. Add connection-string and metadata tests.
+
+### Updating Dify Knowledge Base Behavior
+
+1. Check the official Dify API reference first.
+2. Update `core/dify/dify_client.py` for low-level endpoint or HTTP behavior.
+3. Update `service/dify_service.py` for upload workflow behavior.
+4. Add tests in `test/test_dify_client.py` and/or `test/test_dify_service.py`.
+5. Verify with focused tests and, if possible, remote plugin debugging.
+
+### Updating Prompts
+
+- Prompt templates live in `prompt/`.
+- Keep prompt-building helpers deterministic and testable.
+- Preserve dialect-specific behavior.
+- Add tests when prompt structure changes affect tool output.
+
+## Git and PR Rules
+
+- Before staging, run `git status --short`.
+- Stage explicit files only in mixed worktrees.
+- Do not stage `.env.example` if it contains real local values.
+- Do not stage version bumps unless the user requested a release/version update.
+- Use Chinese conventional commit prefixes:
+
+```text
+feat: 添加新功能描述
+fix: 修复问题描述
+refactor: 重构代码描述
+docs: 更新文档描述
+test: 添加测试描述
+```
+
+Before commit or PR:
+
+```bash
+uv run --no-sync pytest <relevant tests>
+git diff --cached --check
+```
+
+## Release and Version Updates
+
+When releasing a new version, update all relevant version surfaces together:
+
+1. `manifest.yaml` top-level `version`
+2. `manifest.yaml` `meta.version`
+3. `pyproject.toml` project `version`
+4. `README.md` version badge and text
+5. `README_CN.md` version badge and text
+6. Any project guide that explicitly states the current version
+
+Do not perform these version updates as part of an unrelated bugfix.
+
+## Troubleshooting
+
+### Authorization Fails During Provider Validation
+
+Check:
+
+- `_validate_credentials` raises `ToolProviderCredentialValidationError`, not raw `ValueError`.
+- Dify API errors preserve useful messages.
+- Schema generation succeeded before upload.
+- Dataset API key is a Knowledge Base API key.
+- No secrets are printed in logs.
+
+### Dify API Returns 502 or Timeout for Internal IPs
+
+Check:
+
+- `core/dify/dify_client.py` uses `httpx.Client(..., trust_env=False)`.
+- The base URL includes `/v1`.
+- The Dify host is reachable from the plugin process.
+- The request did not go through an HTTP proxy.
+
+### Dataset Already Exists but Cannot Be Found
+
+Check:
+
+- `service/dify_service.py` paginates `GET /datasets`.
+- 409 from `POST /datasets` triggers another paginated lookup.
+- The API key has permission to list the target Knowledge Base.
+- The dataset name is exact and within Dify's name constraints.
+
+### Document Upload Fails with 404 or 405
+
+Check:
+
+- Use `create-by-text` / `create-by-file`, not `create_by_text` / `create_by_file`.
+- `client.dataset_id` is set before uploading.
+- `process_rule` matches Dify's current API shape.
+
+### Dependency Install Fails on macOS arm64
+
+Check:
+
+- `dmpython` and `dmsqlalchemy` have Linux/Windows platform markers.
+- `psycopg2` source package is not declared.
+- `psycopg2-binary` is present.
+- `uv.lock` has been refreshed after metadata changes.
+
+### Plugin Does Not Load
+
+Check:
+
+- `manifest.yaml` is valid YAML.
+- `provider/provider.yaml` references existing tool YAML files.
+- Python version is compatible with the Dify plugin runner.
+- `extra.python.source` and provider class name are correct.
+
+## Final Checklist for Agents
+
+Before saying a fix is complete:
+
+- Read the relevant code path and official Dify docs if the behavior touches Dify APIs.
+- Add or update regression tests for the bug.
+- Run focused tests and report the exact command.
+- Run `git diff --check` or `git diff --cached --check` for the files in scope.
+- State any skipped tests or environment blockers honestly.
+- Mention unrelated dirty files that were intentionally left untouched.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 SchemaRAG is a **Dify plugin** that automates database schema analysis and enables natural language to SQL query conversion. It provides intelligent database querying capabilities for the Dify platform.
 
 - **Type:** Tool Provider Plugin for Dify
-- **Version:** 0.1.6
+- **Version:** 0.1.7
 - **Language:** Python 3.12+
 - **License:** Apache-2.0
 - **Author:** joto (JOTO-AI)
@@ -306,7 +306,7 @@ test: 添加测试描述
 
 ### Examples from History
 ```
-feat: 更新版本号至0.1.6，优化文档和元数据描述
+feat: 更新版本号至0.1.7，优化文档和元数据描述
 feat: 优化SQL执行器和工具，重构缓存机制，增强SQL清理与验证功能
 feat: 添加SQL自动纠错服务和相关测试用例，集成LLM反馈机制以修复SQL错误
 fix: 修正示例工作流下载链接，确保指向正确的路径

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # SchemaRAG Database Schema RAG Plugin
 
-[![Version](https://img.shields.io/badge/version-0.1.6-blue.svg)](https://github.com/weijunjiang123/schemarag)
+[![Version](https://img.shields.io/badge/version-0.1.7-blue.svg)](https://github.com/weijunjiang123/schemarag)
 [![Python](https://img.shields.io/badge/python-3.8+-green.svg)](https://www.python.org/)
 
 **Author:** joto  
-**Version:** 0.1.6 
+**Version:** 0.1.7 
 **Type:** tool  
 **Repository:** <https://github.com/JOTO-AI/SchemaRAG-dify-plugin>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,10 +1,10 @@
 # SchemaRAG 数据库架构RAG插件
 
-[![Version](https://img.shields.io/badge/version-0.1.6-blue.svg)](https://github.com/weijunjiang123/schemarag)
+[![Version](https://img.shields.io/badge/version-0.1.7-blue.svg)](https://github.com/weijunjiang123/schemarag)
 [![Python](https://img.shields.io/badge/python-3.8+-green.svg)](https://www.python.org/)
 
 **作者:** joto  
-**版本:** 0.1.6 
+**版本:** 0.1.7 
 **类型:** 工具
 **仓库:** <https://github.com/JOTO-AI/SchemaRAG-dify-plugin>
 

--- a/core/dify/dify_client.py
+++ b/core/dify/dify_client.py
@@ -8,9 +8,15 @@ logger = logging.getLogger(__name__)
 
 
 class DifyClient:
+    DEFAULT_TIMEOUT = 30.0
+
     def __init__(self, api_key, base_url: str):
         self.api_key = api_key
         self.base_url = base_url
+
+    def _create_http_client(self):
+        """创建 HTTP 客户端，避免内网 Dify API 被环境代理劫持。"""
+        return httpx.Client(timeout=self.DEFAULT_TIMEOUT, trust_env=False)
 
     def _send_request(self, method, endpoint, json=None, params=None, stream=False):
         headers = {
@@ -20,7 +26,7 @@ class DifyClient:
 
         url = f"{self.base_url}{endpoint}"
         try:
-            with httpx.Client() as client:
+            with self._create_http_client() as client:
                 response = client.request(
                     method, url, json=json, params=params, headers=headers
                 )
@@ -42,6 +48,8 @@ class DifyClient:
         except httpx.RequestError as e:
             logger.error(f"请求异常: {str(e)}")
             raise ValueError(f"API请求异常: {str(e)}")
+        except ValueError:
+            raise
         except Exception as e:
             logger.error(f"未知异常: {str(e)}")
             raise ValueError(f"未知错误: {str(e)}")
@@ -50,7 +58,7 @@ class DifyClient:
         headers = {"Authorization": f"Bearer {self.api_key}"}
 
         url = f"{self.base_url}{endpoint}"
-        with httpx.Client() as client:
+        with self._create_http_client() as client:
             response = client.request(
                 method, url, data=data, headers=headers, files=files
             )
@@ -268,7 +276,7 @@ class KnowledgeBaseClient(DifyClient):
         }
         if extra_params is not None and isinstance(extra_params, dict):
             data.update(extra_params)
-        url = f"/datasets/{self._get_dataset_id()}/document/create_by_text"
+        url = f"/datasets/{self._get_dataset_id()}/document/create-by-text"
         return self._send_request("POST", url, json=data, **kwargs)
 
     def update_document_by_text(
@@ -304,7 +312,7 @@ class KnowledgeBaseClient(DifyClient):
         if extra_params is not None and isinstance(extra_params, dict):
             data.update(extra_params)
         url = (
-            f"/datasets/{self._get_dataset_id()}/documents/{document_id}/update_by_text"
+            f"/datasets/{self._get_dataset_id()}/documents/{document_id}/update-by-text"
         )
         return self._send_request("POST", url, json=data, **kwargs)
 
@@ -358,7 +366,7 @@ class KnowledgeBaseClient(DifyClient):
             if original_document_id is not None:
                 data["original_document_id"] = original_document_id
 
-            url = f"/datasets/{self._get_dataset_id()}/document/create_by_file"
+            url = f"/datasets/{self._get_dataset_id()}/document/create-by-file"
             return self._send_request_with_files(
                 "POST", url, {"data": json.dumps(data)}, files
             )
@@ -407,7 +415,7 @@ class KnowledgeBaseClient(DifyClient):
             data = {}
             if extra_params is not None and isinstance(extra_params, dict):
                 data.update(extra_params)
-            url = f"/datasets/{self._get_dataset_id()}/documents/{document_id}/update_by_file"
+            url = f"/datasets/{self._get_dataset_id()}/documents/{document_id}/update-by-file"
             return self._send_request_with_files(
                 "POST", url, {"data": json.dumps(data)}, files
             )

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.6
+version: 0.1.7
 type: plugin
 author: joto
 name: schemarag
@@ -35,7 +35,7 @@ plugins:
   tools:
     - provider/provider.yaml
 meta:
-  version: 0.1.6
+  version: 0.1.7
   arch:
     - amd64
     - arm64

--- a/provider/build_schema_rag.py
+++ b/provider/build_schema_rag.py
@@ -10,6 +10,7 @@ sys.path.append(
 )  # 添加上级目录到路径中
 
 from dify_plugin import ToolProvider
+from dify_plugin.errors.tool import ToolProviderCredentialValidationError
 from tools.text2sql import Text2SQLTool
 from tools.sql_executer import SQLExecuterTool
 from config import DatabaseConfig, LoggerConfig, DifyUploadConfig
@@ -40,62 +41,90 @@ class SchemaRAGBuilderProvider(ToolProvider):
         """
         Validate the credentials and build schema RAG
         """
-        # 验证必要的凭据
-        api_uri = credentials.get("api_uri")
-        dataset_api_key = credentials.get("dataset_api_key")
-        db_type = credentials.get("db_type")
-        db_host = credentials.get("db_host")
-        db_user = credentials.get("db_user")
-        db_password = credentials.get("db_password")
-        db_name = credentials.get("db_name")
-        # build_rag = credentials.get("build_rag", True)
+        try:
+            # 验证必要的凭据
+            api_uri = credentials.get("api_uri")
+            dataset_api_key = credentials.get("dataset_api_key")
+            db_type = credentials.get("db_type")
+            db_host = credentials.get("db_host")
+            db_user = credentials.get("db_user")
+            db_password = credentials.get("db_password")
+            db_name = credentials.get("db_name")
+            # build_rag = credentials.get("build_rag", True)
 
-        # 验证API相关参数
-        if not api_uri:
-            raise ValueError("API URI is required")
+            # 验证API相关参数
+            if not api_uri:
+                raise ToolProviderCredentialValidationError("API URI is required")
 
-        if not dataset_api_key:
-            raise ValueError("Dataset API key is required")
+            if not dataset_api_key:
+                raise ToolProviderCredentialValidationError(
+                    "Dataset API key is required"
+                )
 
-        # 验证数据库相关参数
-        if not db_type:
-            raise ValueError("Database type is required")
+            # 验证数据库相关参数
+            if not db_type:
+                raise ToolProviderCredentialValidationError(
+                    "Database type is required"
+                )
 
-        # SQLite 只需要数据库名称（文件路径）
-        if db_type == "sqlite":
-            if not db_name:
-                raise ValueError("Database name (file path) is required for SQLite")
-        elif db_type == "doris":
-            # Doris需要host, port, user, password, database
-            if not db_host:
-                raise ValueError("Doris database host is required")
-            if not db_user:
-                raise ValueError("Doris database user is required")
-            if not db_password:
-                raise ValueError("Doris database password is required")
-            if not db_name:
-                raise ValueError("Doris database name is required")
-        else:
-            # 其他数据库类型需要完整的连接信息
-            if not db_host:
-                raise ValueError("Database host is required")
+            # SQLite 只需要数据库名称（文件路径）
+            if db_type == "sqlite":
+                if not db_name:
+                    raise ToolProviderCredentialValidationError(
+                        "Database name (file path) is required for SQLite"
+                    )
+            elif db_type == "doris":
+                # Doris需要host, port, user, password, database
+                if not db_host:
+                    raise ToolProviderCredentialValidationError(
+                        "Doris database host is required"
+                    )
+                if not db_user:
+                    raise ToolProviderCredentialValidationError(
+                        "Doris database user is required"
+                    )
+                if not db_password:
+                    raise ToolProviderCredentialValidationError(
+                        "Doris database password is required"
+                    )
+                if not db_name:
+                    raise ToolProviderCredentialValidationError(
+                        "Doris database name is required"
+                    )
+            else:
+                # 其他数据库类型需要完整的连接信息
+                if not db_host:
+                    raise ToolProviderCredentialValidationError(
+                        "Database host is required"
+                    )
 
-            if not db_user:
-                raise ValueError("Database user is required")
+                if not db_user:
+                    raise ToolProviderCredentialValidationError(
+                        "Database user is required"
+                    )
 
-            if not db_password:
-                raise ValueError("Database password is required")
+                if not db_password:
+                    raise ToolProviderCredentialValidationError(
+                        "Database password is required"
+                    )
 
-            if not db_name:
-                raise ValueError("Database name is required")
+                if not db_name:
+                    raise ToolProviderCredentialValidationError(
+                        "Database name is required"
+                    )
 
-        self._build_schema_rag(credentials)
-        # 凭据验证成功后，根据build_rag参数决定是否构建schema知识库
-        # if build_rag:
-        #     self._build_schema_rag(credentials)
-        # else:
-        #     # 记录跳过构建的信息
-        #     logging.info("🚫 build_rag参数为False，跳过Schema RAG构建")
+            self._build_schema_rag(credentials)
+            # 凭据验证成功后，根据build_rag参数决定是否构建schema知识库
+            # if build_rag:
+            #     self._build_schema_rag(credentials)
+            # else:
+            #     # 记录跳过构建的信息
+            #     logging.info("🚫 build_rag参数为False，跳过Schema RAG构建")
+        except ToolProviderCredentialValidationError:
+            raise
+        except Exception as e:
+            logging.error(f"❌ Provider凭据校验失败: {e}")
+            raise ToolProviderCredentialValidationError(str(e)) from e
 
     def _build_schema_rag(self, credentials: dict[str, Any]) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "SchemaRAG"
-version = "0.1.6"
+version = "0.1.7"
 description = "Build database schema for RAG in Dify dataset"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -17,9 +17,8 @@ dependencies = [
     "pymssql",
     "oracledb",
     "pytest>=8.4.1",
-    "dmpython>=2.5.22",
-    "dmsqlalchemy>=2.0.0",  # 达梦数据库 SQLAlchemy 方言适配器
-    "psycopg2>=2.9.10",
+    "dmpython>=2.5.22; sys_platform == 'linux' or sys_platform == 'win32'",
+    "dmsqlalchemy>=2.0.0; sys_platform == 'linux' or sys_platform == 'win32'",  # 达梦数据库 SQLAlchemy 方言适配器
     "openpyxl>=3.1.5",
     "xlrd>=2.0.2",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ tabulate
 # 额外的数据库驱动
 pymssql
 oracledb
-dmPython
-dmSQLAlchemy  # 达梦数据库 SQLAlchemy 方言适配器
+dmPython; sys_platform == "linux" or sys_platform == "win32"
+dmSQLAlchemy; sys_platform == "linux" or sys_platform == "win32"  # 达梦数据库 SQLAlchemy 方言适配器
 
 # LLM 智能绘图模块依赖
 pydantic>=2.0.0

--- a/service/dify_service.py
+++ b/service/dify_service.py
@@ -23,6 +23,8 @@ except ImportError:
 class DifyUploader:
     """Dify文件上传器"""
 
+    DATASET_PAGE_SIZE = 100
+
     def __init__(self, config: DifyUploadConfig, logger: logging.Logger):
         if KnowledgeBaseClient is None:
             raise ImportError(
@@ -41,19 +43,28 @@ class DifyUploader:
             self.logger.info(f"从缓存中获取数据集ID: {dataset_name}")
             return self._dataset_cache[dataset_name]
 
-        # 首先尝试查找现有数据集
+        # 首先尝试分页查找现有数据集
         def try_find_existing_dataset():
             try:
-                response_data = self.client.list_datasets().json()
-                datasets = response_data.get("data", [])
-                for dataset in datasets:
-                    if dataset.get("name") == dataset_name:
-                        dataset_id = dataset.get("id")
-                        self.logger.info(
-                            f"找到现有数据集: {dataset_name} (ID: {dataset_id})"
-                        )
-                        self._dataset_cache[dataset_name] = dataset_id
-                        return dataset_id
+                page = 1
+                while True:
+                    response_data = self.client.list_datasets(
+                        page=page, page_size=self.DATASET_PAGE_SIZE
+                    ).json()
+                    datasets = response_data.get("data", [])
+                    for dataset in datasets:
+                        if dataset.get("name") == dataset_name:
+                            dataset_id = dataset.get("id")
+                            self.logger.info(
+                                f"找到现有数据集: {dataset_name} (ID: {dataset_id})"
+                            )
+                            self._dataset_cache[dataset_name] = dataset_id
+                            return dataset_id
+
+                    if not self._has_next_dataset_page(response_data, page, datasets):
+                        return None
+                    page += 1
+
                 return None
             except Exception as e:
                 self.logger.warning(f"查找现有数据集时出错: {e}")
@@ -87,14 +98,29 @@ class DifyUploader:
                 if existing_dataset_id:
                     return existing_dataset_id
                 else:
-                    # 如果还是找不到，可能是权限问题或其他问题，但不应该抛出异常
-                    # 因为数据集确实存在，只是我们无法访问它
-                    self.logger.warning(f"数据集 {dataset_name} 应该存在但无法找到，可能存在权限问题")
-                    # 尝试使用数据集名称作为最后的手段
-                    raise Exception(f"数据集 {dataset_name} 已存在但无法获取其ID，请检查权限设置")
+                    self.logger.warning(
+                        f"数据集 {dataset_name} 已存在但无法找到，可能存在权限问题"
+                    )
+                    raise Exception(
+                        f"数据集 {dataset_name} 已存在但无法获取其ID，请检查权限设置"
+                    )
             
             self.logger.error(f"创建数据集 {dataset_name} 失败: {e}")
             raise
+
+    def _has_next_dataset_page(
+        self, response_data: dict, page: int, datasets: list
+    ) -> bool:
+        """根据 Dify 分页响应判断是否还有下一页数据集。"""
+        if response_data.get("has_more") is True:
+            return True
+
+        total = response_data.get("total")
+        page_size = response_data.get("limit") or len(datasets)
+        if isinstance(total, int) and isinstance(page_size, int) and page_size > 0:
+            return page * page_size < total
+
+        return False
 
     def upload_file(self, file_path: str):
         """上传单个文件到指定的数据集"""

--- a/test/test_dependency_metadata.py
+++ b/test/test_dependency_metadata.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+测试平台相关依赖声明
+"""
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestDependencyMetadata(unittest.TestCase):
+    """依赖元数据测试"""
+
+    def _read_pyproject(self) -> str:
+        """读取 pyproject.toml 内容"""
+        return (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    def _read_requirements(self) -> str:
+        """读取 requirements.txt 内容"""
+        return (PROJECT_ROOT / "requirements.txt").read_text(encoding="utf-8")
+
+    def _find_dependency_line(self, package_name: str) -> str:
+        """查找指定依赖声明行"""
+        pattern = re.compile(
+            rf'^\s*"({re.escape(package_name)}[^"]*)",',
+            re.IGNORECASE | re.MULTILINE,
+        )
+        match = pattern.search(self._read_pyproject())
+        self.assertIsNotNone(match, f"未找到依赖声明: {package_name}")
+        return match.group(1)
+
+    def test_dameng_driver_dependencies_are_not_installed_on_macos(self):
+        """达梦驱动依赖不应在 macOS 上安装"""
+        for package_name in ("dmpython", "dmsqlalchemy"):
+            dependency = self._find_dependency_line(package_name)
+
+            self.assertIn("sys_platform", dependency)
+            self.assertIn("linux", dependency)
+            self.assertIn("win32", dependency)
+
+            if sys.platform == "darwin":
+                self.assertNotIn('sys_platform == "darwin"', dependency)
+
+        requirements = self._read_requirements().lower()
+        self.assertIn(
+            'dmpython; sys_platform == "linux" or sys_platform == "win32"',
+            requirements,
+        )
+        self.assertIn(
+            'dmsqlalchemy; sys_platform == "linux" or sys_platform == "win32"',
+            requirements,
+        )
+
+    def test_postgresql_uses_binary_driver_package(self):
+        """PostgreSQL 依赖使用 binary 包避免本地编译 pg_config"""
+        pyproject = self._read_pyproject().lower()
+
+        self.assertIn("psycopg2-binary", pyproject)
+        self.assertNotRegex(pyproject, r'"psycopg2[<>=,;\s"]')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_dify_client.py
+++ b/test/test_dify_client.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+测试 Dify API 客户端
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.dify.dify_client import DifyClient, KnowledgeBaseClient  # noqa: E402
+
+
+class TestDifyClient(unittest.TestCase):
+    """Dify API 客户端测试"""
+
+    def _mock_response(self, status_code=200, body=None):
+        """创建 HTTP 响应 Mock"""
+        response = Mock()
+        response.status_code = status_code
+        response.json.return_value = body or {"ok": True}
+        response.raise_for_status.return_value = None
+        return response
+
+    @patch("core.dify.dify_client.httpx.Client")
+    def test_json_requests_ignore_environment_proxies(self, mock_client_class):
+        """JSON 请求不读取环境代理配置，避免内网 Dify API 误走代理"""
+        response = self._mock_response()
+        client_instance = mock_client_class.return_value.__enter__.return_value
+        client_instance.request.return_value = response
+
+        client = DifyClient("dataset-key", "http://192.168.198.169/v1")
+        result = client._send_request("GET", "/datasets")
+
+        self.assertIs(result, response)
+        mock_client_class.assert_called_once_with(timeout=30.0, trust_env=False)
+        client_instance.request.assert_called_once()
+
+    @patch("core.dify.dify_client.httpx.Client")
+    def test_http_status_error_keeps_api_error_message(self, mock_client_class):
+        """HTTP 状态错误保留 API 错误信息，不包装成未知错误"""
+        response = self._mock_response(
+            status_code=409,
+            body={"message": "The dataset name already exists."},
+        )
+        response.text = ""
+        client_instance = mock_client_class.return_value.__enter__.return_value
+        client_instance.request.return_value = response
+
+        client = DifyClient("dataset-key", "http://192.168.198.169/v1")
+
+        with self.assertRaises(ValueError) as context:
+            client._send_request("POST", "/datasets")
+
+        self.assertEqual(
+            str(context.exception),
+            "API请求失败: HTTP 409 - The dataset name already exists.",
+        )
+
+    @patch("core.dify.dify_client.httpx.Client")
+    def test_file_requests_ignore_environment_proxies(self, mock_client_class):
+        """文件上传请求也不读取环境代理配置"""
+        response = self._mock_response()
+        client_instance = mock_client_class.return_value.__enter__.return_value
+        client_instance.request.return_value = response
+
+        client = DifyClient("dataset-key", "http://192.168.198.169/v1")
+        result = client._send_request_with_files(
+            "POST",
+            "/datasets/dataset-id/document/create-by-file",
+            {"data": "{}"},
+            {"file": ("schema.txt", b"content", "text/plain")},
+        )
+
+        self.assertIs(result, response)
+        mock_client_class.assert_called_once_with(timeout=30.0, trust_env=False)
+
+    @patch.object(KnowledgeBaseClient, "_send_request")
+    def test_create_document_by_text_uses_current_official_endpoint(
+        self, send_request
+    ):
+        """从文本创建文档使用当前官方 create-by-text 路径"""
+        client = KnowledgeBaseClient(
+            "dataset-key",
+            "http://192.168.198.169/v1",
+            dataset_id="dataset-id",
+        )
+
+        client.create_document_by_text("schema", "content")
+
+        send_request.assert_called_once()
+        self.assertEqual(
+            send_request.call_args.args[:2],
+            ("POST", "/datasets/dataset-id/document/create-by-text"),
+        )
+
+    @patch.object(KnowledgeBaseClient, "_send_request_with_files")
+    @patch("core.dify.dify_client.os.path.getsize", return_value=10)
+    @patch("core.dify.dify_client.os.path.exists", return_value=True)
+    @patch("builtins.open")
+    def test_create_document_by_file_uses_current_official_endpoint(
+        self,
+        mock_open,
+        exists,
+        getsize,
+        send_request_with_files,
+    ):
+        """从文件创建文档使用当前官方 create-by-file 路径"""
+        mock_open.return_value.__enter__.return_value = Mock()
+        client = KnowledgeBaseClient(
+            "dataset-key",
+            "http://192.168.198.169/v1",
+            dataset_id="dataset-id",
+        )
+
+        client.create_document_by_file("/tmp/schema.txt")
+
+        send_request_with_files.assert_called_once()
+        self.assertEqual(
+            send_request_with_files.call_args.args[:2],
+            ("POST", "/datasets/dataset-id/document/create-by-file"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_dify_service.py
+++ b/test/test_dify_service.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+测试 Dify 上传服务
+"""
+
+import logging
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from config import DifyUploadConfig  # noqa: E402
+from service.dify_service import DifyUploader  # noqa: E402
+
+
+class TestDifyUploader(unittest.TestCase):
+    """Dify 上传服务测试"""
+
+    def _response(self, data):
+        """创建响应 Mock"""
+        response = Mock()
+        response.json.return_value = data
+        return response
+
+    def _create_uploader(self):
+        """创建测试上传器"""
+        config = DifyUploadConfig(
+            api_key="dataset-key",
+            base_url="http://dify.example/v1",
+        )
+        return DifyUploader(config, logging.getLogger("test.dify_uploader"))
+
+    @patch("service.dify_service.KnowledgeBaseClient")
+    def test_finds_existing_dataset_across_pages(self, client_class):
+        """查找现有知识库时分页搜索所有可见数据集"""
+        client = client_class.return_value
+        client.list_datasets.side_effect = [
+            self._response(
+                {
+                    "data": [{"id": "other-id", "name": "other_schema"}],
+                    "page": 1,
+                    "limit": 1,
+                    "total": 2,
+                    "has_more": True,
+                }
+            ),
+            self._response(
+                {
+                    "data": [{"id": "target-id", "name": "haitian_schema"}],
+                    "page": 2,
+                    "limit": 1,
+                    "total": 2,
+                    "has_more": False,
+                }
+            ),
+        ]
+        uploader = self._create_uploader()
+
+        dataset_id = uploader._get_or_create_dataset("haitian_schema")
+
+        self.assertEqual(dataset_id, "target-id")
+        self.assertEqual(client.list_datasets.call_count, 2)
+        client.create_dataset.assert_not_called()
+
+    @patch("service.dify_service.KnowledgeBaseClient")
+    def test_conflict_creation_retries_paginated_lookup(self, client_class):
+        """创建知识库撞名后重新分页查找已存在知识库"""
+        client = client_class.return_value
+        client.list_datasets.side_effect = [
+            self._response(
+                {
+                    "data": [{"id": "other-id", "name": "other_schema"}],
+                    "page": 1,
+                    "limit": 1,
+                    "total": 1,
+                    "has_more": False,
+                }
+            ),
+            self._response(
+                {
+                    "data": [{"id": "other-id", "name": "other_schema"}],
+                    "page": 1,
+                    "limit": 1,
+                    "total": 2,
+                    "has_more": True,
+                }
+            ),
+            self._response(
+                {
+                    "data": [{"id": "target-id", "name": "haitian_schema"}],
+                    "page": 2,
+                    "limit": 1,
+                    "total": 2,
+                    "has_more": False,
+                }
+            ),
+        ]
+        client.create_dataset.side_effect = ValueError(
+            "API请求失败: HTTP 409 - The dataset name already exists."
+        )
+        uploader = self._create_uploader()
+
+        dataset_id = uploader._get_or_create_dataset("haitian_schema")
+
+        self.assertEqual(dataset_id, "target-id")
+        client.create_dataset.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_provider_credentials.py
+++ b/test/test_provider_credentials.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+测试 Provider 凭据校验异常类型
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+class ToolProviderCredentialValidationError(Exception):
+    """测试用 Dify 凭据校验异常"""
+
+
+def _install_provider_import_stubs():
+    """安装 Provider 单元测试所需的最小依赖桩。"""
+    dify_plugin = types.ModuleType("dify_plugin")
+    errors = types.ModuleType("dify_plugin.errors")
+    tool_errors = types.ModuleType("dify_plugin.errors.tool")
+    tools_text2sql = types.ModuleType("tools.text2sql")
+    tools_sql_executer = types.ModuleType("tools.sql_executer")
+    schema_builder = types.ModuleType("service.schema_builder")
+    logger_format = types.ModuleType("dify_plugin.config.logger_format")
+    config_module = types.ModuleType("dify_plugin.config")
+
+    class ToolProvider:
+        pass
+
+    class Text2SQLTool:
+        pass
+
+    class SQLExecuterTool:
+        pass
+
+    class SchemaRAGBuilder:
+        pass
+
+    dify_plugin.ToolProvider = ToolProvider
+    tool_errors.ToolProviderCredentialValidationError = (
+        ToolProviderCredentialValidationError
+    )
+    tools_text2sql.Text2SQLTool = Text2SQLTool
+    tools_sql_executer.SQLExecuterTool = SQLExecuterTool
+    schema_builder.SchemaRAGBuilder = SchemaRAGBuilder
+    logger_format.plugin_logger_handler = None
+
+    sys.modules["dify_plugin"] = dify_plugin
+    sys.modules["dify_plugin.errors"] = errors
+    sys.modules["dify_plugin.errors.tool"] = tool_errors
+    sys.modules["dify_plugin.config"] = config_module
+    sys.modules["dify_plugin.config.logger_format"] = logger_format
+    sys.modules["tools.text2sql"] = tools_text2sql
+    sys.modules["tools.sql_executer"] = tools_sql_executer
+    sys.modules["service.schema_builder"] = schema_builder
+
+
+_install_provider_import_stubs()
+
+from provider.build_schema_rag import SchemaRAGBuilderProvider  # noqa: E402
+
+
+VALID_CREDENTIALS = {
+    "api_uri": "http://localhost/v1",
+    "dataset_api_key": "dataset-test",
+    "db_type": "mysql",
+    "db_host": "localhost",
+    "db_port": "3306",
+    "db_user": "root",
+    "db_password": "password",
+    "db_name": "test_db",
+}
+
+
+class TestProviderCredentials(unittest.TestCase):
+    """Provider 凭据校验测试"""
+
+    def setUp(self):
+        """测试前准备"""
+        self.provider = SchemaRAGBuilderProvider()
+
+    def test_missing_required_credential_raises_dify_validation_error(self):
+        """缺少必要凭据时抛出 Dify 官方凭据校验异常"""
+        credentials = VALID_CREDENTIALS | {"api_uri": ""}
+
+        with self.assertRaises(ToolProviderCredentialValidationError):
+            self.provider._validate_credentials(credentials)
+
+    def test_build_failure_is_wrapped_as_dify_validation_error(self):
+        """Schema RAG 构建失败时包装为 Dify 官方凭据校验异常"""
+        with patch.object(
+            self.provider,
+            "_build_schema_rag",
+            side_effect=RuntimeError("数据库连接失败"),
+        ):
+            with self.assertRaises(ToolProviderCredentialValidationError) as context:
+                self.provider._validate_credentials(VALID_CREDENTIALS)
+
+        self.assertIn("数据库连接失败", str(context.exception))
+
+    def test_valid_credentials_trigger_schema_build(self):
+        """凭据完整时继续触发现有 Schema RAG 构建流程"""
+        with patch.object(self.provider, "_build_schema_rag") as build_schema:
+            self.provider._validate_credentials(VALID_CREDENTIALS)
+
+        build_schema.assert_called_once_with(VALID_CREDENTIALS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -219,6 +219,18 @@ wheels = [
 ]
 
 [[package]]
+name = "dmsqlalchemy"
+version = "2.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dmpython" },
+    { name = "sqlalchemy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/aa/b5154b3d0555c9bde5cd1b494514793bc2755df327b03e050232e02b6f59/dmsqlalchemy-2.0.12-py3-none-any.whl", hash = "sha256:e20a9fa4120e681c9ff660ae8abdcd51ecb6e86fab6837924a5e86a8a94fdbb3", size = 59252, upload-time = "2026-04-27T06:32:58.27Z" },
+]
+
+[[package]]
 name = "dpkt"
 version = "1.9.8"
 source = { registry = "https://pypi.org/simple" }
@@ -675,17 +687,6 @@ wheels = [
 ]
 
 [[package]]
-name = "psycopg2"
-version = "2.9.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/8d/9d12bc8677c24dad342ec777529bce705b3e785fa05d85122b5502b9ab55/psycopg2-2.9.11.tar.gz", hash = "sha256:964d31caf728e217c697ff77ea69c2ba0865fa41ec20bb00f0977e62fdcc52e3", size = 379598, upload-time = "2025-10-10T11:14:46.075Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/bf/635fbe5dd10ed200afbbfbe98f8602829252ca1cce81cc48fb25ed8dadc0/psycopg2-2.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:e03e4a6dbe87ff81540b434f2e5dc2bddad10296db5eea7bdc995bf5f4162938", size = 2713969, upload-time = "2025-10-10T11:10:15.946Z" },
-    { url = "https://files.pythonhosted.org/packages/88/5a/18c8cb13fc6908dc41a483d2c14d927a7a3f29883748747e8cb625da6587/psycopg2-2.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:8dc379166b5b7d5ea66dcebf433011dfc51a7bb8a5fc12367fa05668e5fc53c8", size = 2714048, upload-time = "2025-10-10T11:10:19.816Z" },
-    { url = "https://files.pythonhosted.org/packages/47/08/737aa39c78d705a7ce58248d00eeba0e9fc36be488f9b672b88736fbb1f7/psycopg2-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:f10a48acba5fe6e312b891f290b4d2ca595fc9a06850fe53320beac353575578", size = 2803738, upload-time = "2025-10-10T11:10:23.196Z" },
-]
-
-[[package]]
 name = "psycopg2-binary"
 version = "2.9.10"
 source = { registry = "https://pypi.org/simple" }
@@ -965,17 +966,17 @@ wheels = [
 
 [[package]]
 name = "schemarag"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "dify-client" },
     { name = "dify-plugin" },
-    { name = "dmpython" },
+    { name = "dmpython", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "dmsqlalchemy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "httpx" },
     { name = "openpyxl" },
     { name = "oracledb" },
     { name = "pandas" },
-    { name = "psycopg2" },
     { name = "psycopg2-binary" },
     { name = "pymssql" },
     { name = "pymysql" },
@@ -989,12 +990,12 @@ dependencies = [
 requires-dist = [
     { name = "dify-client" },
     { name = "dify-plugin" },
-    { name = "dmpython", specifier = ">=2.5.22" },
+    { name = "dmpython", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = ">=2.5.22" },
+    { name = "dmsqlalchemy", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = ">=2.0.0" },
     { name = "httpx" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "oracledb" },
     { name = "pandas", specifier = ">=2.3.1" },
-    { name = "psycopg2", specifier = ">=2.9.10" },
     { name = "psycopg2-binary" },
     { name = "pymssql" },
     { name = "pymysql" },


### PR DESCRIPTION
## Summary

修复 Dify 插件在保存授权信息和构建 Schema RAG 时的几个问题：

- 按 Dify 插件规范将 provider 凭据校验失败包装为 `ToolProviderCredentialValidationError`
- 避免 macOS arm64 安装不可用的达梦驱动，并移除源码版 `psycopg2` 依赖
- Dify API 客户端禁用环境代理，避免内网 Dify 地址被代理劫持
- 更新文档上传接口路径为当前官方 `create-by-*` / `update-by-*` 格式
- 分页查找已有知识库，修复同名知识库不在第一页时误判为权限问题

## Root Cause

授权校验阶段直接构建并上传 Schema RAG，原异常类型不符合 Dify provider 凭据校验约定；同时 Dify API 请求会继承环境代理，内网地址可能走代理失败。后续 409 冲突来自同名知识库已存在，但代码只查第一页数据集，因此找不到已有知识库 ID。

## Validation

- `uv run --no-sync pytest test/test_dify_client.py test/test_dify_service.py test/test_provider_credentials.py test/test_dependency_metadata.py`
- `git diff --cached --check`