### PR TITLE
[codex] 修复 schema 初始化与 SQL 输出问题

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,13 +58,14 @@ class DatabaseConfig:
         # 对用户名和密码进行 URL 编码，处理特殊字符（如 @, #, $ 等）
         encoded_user = quote_plus(self.user)
         encoded_password = quote_plus(self.password)
+        encoded_database = quote(str(self.database or ""), safe="")
         
         if self.type == "postgresql":
-            return f"postgresql+psycopg2://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{self.database}"
+            return f"postgresql+psycopg2://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{encoded_database}"
         elif self.type == "mysql":
-            return f"mysql+pymysql://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{self.database}"
+            return f"mysql+pymysql://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{encoded_database}"
         elif self.type == "mssql":
-            return f"mssql+pymssql://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{self.database}"
+            return f"mssql+pymssql://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{encoded_database}"
         elif self.type == "oracle":
             connect_type = (self.oracle_connect_type or "service_name").strip().lower()
             if connect_type == "sid":
@@ -78,7 +79,8 @@ class DatabaseConfig:
             # 达梦 dmPython.connect() 不接受 database 参数，URI 中不能带 /{database}
             return f"dm+dmPython://{encoded_user}:{encoded_password}@{self.host}:{self.port}"
         elif self.type == "doris":
-            return f"doris+mysql://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{self.database}"
+            # Apache Doris 兼容 MySQL 协议，使用 SQLAlchemy 内置 MySQL 方言连接。
+            return f"mysql+pymysql://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{encoded_database}"
         else:
             raise ValueError(f"Unsupported database type: {self.type}")
 

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@
 import os
 from dataclasses import dataclass
 from typing import Optional
-from urllib.parse import quote_plus
+from urllib.parse import quote, quote_plus
 
 # 尝试导入dotenv，如果失败则忽略。在生产环境中，通常使用环境变量。
 try:
@@ -27,6 +27,14 @@ def get_env_int(key: str, default: Optional[int] = None) -> Optional[int]:
     return int(value) if value is not None else default
 
 
+def get_env_bool(key: str, default: bool = False) -> bool:
+    """从环境变量中获取布尔值"""
+    value = get_env(key)
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
 @dataclass
 class DatabaseConfig:
     """数据库连接配置"""
@@ -37,6 +45,10 @@ class DatabaseConfig:
     user: str = get_env("DB_USER", "root")
     password: str = get_env("DB_PASSWORD", "password")
     database: str = get_env("DB_NAME")
+    schema: Optional[str] = get_env("DB_SCHEMA")
+    oracle_connect_type: str = get_env("ORACLE_CONNECT_TYPE", "service_name")
+    oracle_thick_mode: bool = get_env_bool("ORACLE_THICK_MODE", False)
+    oracle_client_lib_dir: Optional[str] = get_env("ORACLE_CLIENT_LIB_DIR")
 
     def get_connection_string(self) -> str:
         """获取数据库连接字符串"""
@@ -54,8 +66,14 @@ class DatabaseConfig:
         elif self.type == "mssql":
             return f"mssql+pymssql://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{self.database}"
         elif self.type == "oracle":
-            # Oracle 使用 service_name 格式
-            return f"oracle+oracledb://{encoded_user}:{encoded_password}@{self.host}:{self.port}/?service_name={self.database}"
+            connect_type = (self.oracle_connect_type or "service_name").strip().lower()
+            if connect_type == "sid":
+                sid = quote(str(self.database or ""), safe="")
+                return f"oracle+oracledb://{encoded_user}:{encoded_password}@{self.host}:{self.port}/{sid}"
+
+            # Oracle 默认使用 service_name 格式
+            service_name = quote_plus(str(self.database or ""))
+            return f"oracle+oracledb://{encoded_user}:{encoded_password}@{self.host}:{self.port}/?service_name={service_name}"
         elif self.type == "dameng":
             # 达梦 dmPython.connect() 不接受 database 参数，URI 中不能带 /{database}
             return f"dm+dmPython://{encoded_user}:{encoded_password}@{self.host}:{self.port}"

--- a/core/m_schema/schema_engine.py
+++ b/core/m_schema/schema_engine.py
@@ -30,6 +30,7 @@ class SchemaEngine(SQLDatabase):
         max_string_length: int = 300,
         mschema: Optional[MSchema] = None,
         db_name: Optional[str] = "",
+        sample_values_in_table_info: int = 0,
     ):
         # Some dialects (notably Dameng) represent the "database name" as a schema/owner.
         # SQLDatabase must receive the effective schema up-front so inspector/metadata reflect
@@ -58,7 +59,9 @@ class SchemaEngine(SQLDatabase):
             custom_table_info,
             view_support,
             max_string_length,
+            reflect_metadata=False,
         )
+        self._sample_values_in_table_info = sample_values_in_table_info
 
         self._db_name = db_name
         # Dictionary to store table names and their corresponding schema
@@ -87,15 +90,8 @@ class SchemaEngine(SQLDatabase):
 
         # If a schema is specified, filter by that schema and store that value for every table.
         if effective_schema:
-            if self._engine.dialect.name in ["dm", "dameng"]:
-                # 达梦方言的 has_table 兼容性较弱，直接信任 inspector 返回的表名列表
-                self._usable_tables = list(self._usable_tables)
-            else:
-                self._usable_tables = [
-                    table_name
-                    for table_name in self._usable_tables
-                    if self._inspector.has_table(table_name, effective_schema)
-                ]
+            # get_table_names(schema=...) 已经按 schema 返回可见表，避免大库逐表 has_table 反查。
+            self._usable_tables = list(self._usable_tables)
             for table_name in self._usable_tables:
                 self._tables_schemas[table_name] = effective_schema
         else:
@@ -222,10 +218,16 @@ class SchemaEngine(SQLDatabase):
                 if default is not None:
                     default = f"{default}"
 
-                try:
-                    examples = self.fectch_distinct_values(table_name, field_name, 5)
-                except Exception:
-                    examples = []
+                examples = []
+                if self._sample_values_in_table_info > 0:
+                    try:
+                        examples = self.fectch_distinct_values(
+                            table_name,
+                            field_name,
+                            self._sample_values_in_table_info,
+                        )
+                    except Exception:
+                        examples = []
                 examples = examples_to_str(examples)
 
                 self._mschema.add_field(

--- a/core/m_schema/schema_engine.py
+++ b/core/m_schema/schema_engine.py
@@ -7,7 +7,11 @@ from sqlalchemy import (
 
 from sqlalchemy.engine import Engine
 from core.m_schema.sql_database import SQLDatabase
-from utils import examples_to_str, normalize_dameng_schema_name
+from utils import (
+    examples_to_str,
+    normalize_dameng_schema_name,
+    normalize_oracle_schema_name,
+)
 from core.m_schema.m_schema import MSchema
 
 
@@ -34,6 +38,14 @@ class SchemaEngine(SQLDatabase):
         if effective_schema is None and db_name:
             if engine.dialect.name in ["dm", "dameng"]:
                 effective_schema = normalize_dameng_schema_name(db_name)
+            elif engine.dialect.name == "postgresql":
+                effective_schema = "public"
+            elif engine.dialect.name == "mssql":
+                effective_schema = "dbo"
+            elif engine.dialect.name == "oracle":
+                effective_schema = normalize_oracle_schema_name(engine.url.username)
+            elif engine.dialect.name in ["mysql", "doris"]:
+                effective_schema = db_name
 
         super().__init__(
             engine,
@@ -64,6 +76,11 @@ class SchemaEngine(SQLDatabase):
             elif self._engine.dialect.name == "mssql":
                 # For SQL Server, use 'dbo' as default schema
                 effective_schema = "dbo"
+            elif self._engine.dialect.name == "oracle":
+                # Oracle 默认使用登录用户作为 schema/owner，避免扫描所有系统 schema
+                effective_schema = normalize_oracle_schema_name(
+                    self._engine.url.username
+                )
             elif self._engine.dialect.name in ["dm", "dameng"]:
                 # 达梦的 db_name 对应 schema/owner，未加引号按达梦规则转大写
                 effective_schema = normalize_dameng_schema_name(db_name)

--- a/core/m_schema/sql_database.py
+++ b/core/m_schema/sql_database.py
@@ -57,6 +57,7 @@ class SQLDatabase:
         custom_table_info: Optional[dict] = None,
         view_support: bool = False,
         max_string_length: int = 300,
+        reflect_metadata: bool = True,
     ):
         """Create engine from database URI."""
         self._engine = engine
@@ -114,6 +115,9 @@ class SQLDatabase:
         self._max_string_length = max_string_length
 
         self._metadata = metadata or MetaData()
+        if not reflect_metadata:
+            return
+
         # Reflecting metadata can trigger dialect-specific index/introspection code.
         # dmSQLAlchemy has compatibility issues with some SQLAlchemy 2.x versions during
         # index reflection; schema generation in this project relies primarily on the

--- a/provider/build_schema_rag.py
+++ b/provider/build_schema_rag.py
@@ -50,6 +50,21 @@ class SchemaRAGBuilderProvider(ToolProvider):
         except (TypeError, ValueError) as exc:
             raise ValueError("Database port must be a valid integer") from exc
 
+    def _parse_bool_credential(self, value: Any, default: bool = False) -> bool:
+        """解析 Dify 凭据中的布尔值。"""
+        if value in (None, ""):
+            return default
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+    def _parse_optional_text_credential(self, value: Any) -> str | None:
+        """解析可选文本凭据，空字符串视为未配置。"""
+        if value in (None, ""):
+            return None
+        value = str(value).strip()
+        return value or None
+
     def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         """
         Validate the credentials and build schema RAG
@@ -148,7 +163,21 @@ class SchemaRAGBuilderProvider(ToolProvider):
             # 创建数据库配置
             db_type = credentials.get("db_type")
             db_port = self._parse_db_port(credentials)
-
+            db_schema = self._parse_optional_text_credential(
+                credentials.get("db_schema")
+            )
+            oracle_connect_type = (
+                self._parse_optional_text_credential(
+                    credentials.get("oracle_connect_type")
+                )
+                or "service_name"
+            )
+            oracle_thick_mode = self._parse_bool_credential(
+                credentials.get("oracle_thick_mode")
+            )
+            oracle_client_lib_dir = self._parse_optional_text_credential(
+                credentials.get("oracle_client_lib_dir")
+            )
 
             if db_type == "doris":
                 db_config = DatabaseConfig(
@@ -158,6 +187,10 @@ class SchemaRAGBuilderProvider(ToolProvider):
                     user=credentials.get("db_user"),
                     password=credentials.get("db_password"),
                     database=credentials.get("db_name"),
+                    schema=db_schema,
+                    oracle_connect_type=oracle_connect_type,
+                    oracle_thick_mode=oracle_thick_mode,
+                    oracle_client_lib_dir=oracle_client_lib_dir,
                 )
             else:
                 db_config = DatabaseConfig(
@@ -167,6 +200,10 @@ class SchemaRAGBuilderProvider(ToolProvider):
                     user=credentials.get("db_user"),
                     password=credentials.get("db_password"),
                     database=credentials.get("db_name"),
+                    schema=db_schema,
+                    oracle_connect_type=oracle_connect_type,
+                    oracle_thick_mode=oracle_thick_mode,
+                    oracle_client_lib_dir=oracle_client_lib_dir,
                 )
 
             # 创建日志配置

--- a/provider/build_schema_rag.py
+++ b/provider/build_schema_rag.py
@@ -1,8 +1,6 @@
 import os
 from typing import Any
 import sys
-import logging
-from venv import logger
 
 
 sys.path.append(
@@ -14,8 +12,12 @@ from dify_plugin.errors.tool import ToolProviderCredentialValidationError
 from tools.text2sql import Text2SQLTool
 from tools.sql_executer import SQLExecuterTool
 from config import DatabaseConfig, LoggerConfig, DifyUploadConfig
+from service.database_connection import DatabaseConnectionError
+from service.plugin_logging import get_plugin_logger
 from service.schema_builder import SchemaRAGBuilder
-from dify_plugin.config.logger_format import plugin_logger_handler
+
+
+logger = get_plugin_logger(__name__)
 
 
 class SchemaRAGBuilderProvider(ToolProvider):
@@ -151,13 +153,14 @@ class SchemaRAGBuilderProvider(ToolProvider):
         except ToolProviderCredentialValidationError:
             raise
         except Exception as e:
-            logging.error(f"❌ Provider凭据校验失败: {e}")
+            logger.error(f"❌ Provider凭据校验失败: {e}")
             raise ToolProviderCredentialValidationError(str(e)) from e
 
     def _build_schema_rag(self, credentials: dict[str, Any]) -> None:
         """
         Build schema RAG using the provided credentials
         """
+        builder = None
         try:
 
             # 创建数据库配置
@@ -179,41 +182,21 @@ class SchemaRAGBuilderProvider(ToolProvider):
                 credentials.get("oracle_client_lib_dir")
             )
 
-            if db_type == "doris":
-                db_config = DatabaseConfig(
-                    type=db_type,
-                    host=credentials.get("db_host"),
-                    port=db_port,
-                    user=credentials.get("db_user"),
-                    password=credentials.get("db_password"),
-                    database=credentials.get("db_name"),
-                    schema=db_schema,
-                    oracle_connect_type=oracle_connect_type,
-                    oracle_thick_mode=oracle_thick_mode,
-                    oracle_client_lib_dir=oracle_client_lib_dir,
-                )
-            else:
-                db_config = DatabaseConfig(
-                    type=db_type,
-                    host=credentials.get("db_host"),
-                    port=db_port,
-                    user=credentials.get("db_user"),
-                    password=credentials.get("db_password"),
-                    database=credentials.get("db_name"),
-                    schema=db_schema,
-                    oracle_connect_type=oracle_connect_type,
-                    oracle_thick_mode=oracle_thick_mode,
-                    oracle_client_lib_dir=oracle_client_lib_dir,
-                )
+            db_config = DatabaseConfig(
+                type=db_type,
+                host=credentials.get("db_host"),
+                port=db_port,
+                user=credentials.get("db_user"),
+                password=credentials.get("db_password"),
+                database=credentials.get("db_name"),
+                schema=db_schema,
+                oracle_connect_type=oracle_connect_type,
+                oracle_thick_mode=oracle_thick_mode,
+                oracle_client_lib_dir=oracle_client_lib_dir,
+            )
 
             # 创建日志配置
-            logger_config = LoggerConfig(
-                log_level="INFO"
-            )
-            logger = logging.getLogger(__name__)
-            logger.setLevel(logging.INFO)
-            logger.addHandler(plugin_logger_handler)
-            
+            logger_config = LoggerConfig(log_level="INFO")
             # 创建Dify集成配置
             dify_config = DifyUploadConfig(
                 api_key=credentials.get("dataset_api_key"),
@@ -228,35 +211,42 @@ class SchemaRAGBuilderProvider(ToolProvider):
             tables_name = credentials.get("tables_name", "")
             include_tables = None
             if tables_name and tables_name.strip():
-                include_tables = [table.strip() for table in tables_name.split(",") if table.strip()]
-                logging.info(f"📋 指定构建以下表的RAG: {include_tables}")
+                include_tables = [
+                    table.strip()
+                    for table in tables_name.split(",")
+                    if table.strip()
+                ]
+                logger.info(f"📋 指定构建以下表的RAG: {include_tables}")
             else:
-                logging.info("📋 将构建所有表的RAG")
+                logger.info("📋 将构建所有表的RAG")
 
             # 创建构建器实例
-            builder = SchemaRAGBuilder(db_config, logger_config, dify_config, include_tables)
+            builder = SchemaRAGBuilder(
+                db_config,
+                logger_config,
+                dify_config,
+                include_tables,
+                logger=logger,
+            )
+            schema_content = builder.generate_dictionary()
 
-            try:
-                schema_content = builder.generate_dictionary()
+            # 记录成功信息
+            table_count = schema_content.count("#") if schema_content else 0
+            logger.info(f"📊 数据字典生成成功！包含 {table_count} 个表")
 
-                # 记录成功信息
-                table_count = schema_content.count("#") if schema_content else 0
-                logging.info(f"📊 数据字典生成成功！包含 {table_count} 个表")
+            # 上传到 Dify 知识库
+            dataset_name = f"{db_config.database}_schema"
+            builder.upload_text_to_dify(dataset_name, schema_content)
+            logger.info("☁️ 已成功上传到 Dify 知识库")
 
-                # 上传到 Dify 知识库
-                dataset_name = f"{db_config.database}_schema"
-                builder.upload_text_to_dify(dataset_name, schema_content)
-                logging.info("☁️ 已成功上传到 Dify 知识库")
-
-            except Exception as e:
-                logging.error(f"❌ Schema RAG构建失败: {e}")
-                raise ValueError(f"Schema RAG构建失败: {str(e)}")
-            finally:
-                builder.close()
-
+        except DatabaseConnectionError:
+            raise
         except Exception as e:
-            logging.error(f"❌ 配置验证或构建过程中发生错误: {e}")
-            raise ValueError(f"配置验证或构建过程中发生错误: {str(e)}")
+            logger.error(f"❌ Schema RAG构建失败: {e}")
+            raise ValueError(f"Schema RAG构建失败: {str(e)}") from e
+        finally:
+            if builder is not None:
+                builder.close()
 
     def get_tools(self):
         """

--- a/provider/provider.yaml
+++ b/provider/provider.yaml
@@ -140,6 +140,70 @@ credentials_for_provider:
       zh_Hans: 数据库名称
       pt_BR: Database name
 
+  db_schema:
+    type: text-input
+    required: false
+    label:
+      en_US: Database Schema
+      zh_Hans: 数据库 Schema
+      pt_BR: Database Schema
+    placeholder:
+      en_US: Optional schema/owner. Oracle defaults to user, PostgreSQL defaults to public, Dameng defaults to database name.
+      zh_Hans: 可选 schema/owner。Oracle 默认使用用户名，PostgreSQL 默认 public，达梦默认数据库名称。
+      pt_BR: Optional schema/owner. Oracle defaults to user, PostgreSQL defaults to public, Dameng defaults to database name.
+
+  oracle_connect_type:
+    type: select
+    required: false
+    label:
+      en_US: Oracle Connect Type
+      zh_Hans: Oracle 连接类型
+      pt_BR: Oracle Connect Type
+    default: service_name
+    options:
+      - value: service_name
+        label:
+          en_US: Service Name
+          zh_Hans: Service Name
+          pt_BR: Service Name
+      - value: sid
+        label:
+          en_US: SID
+          zh_Hans: SID
+          pt_BR: SID
+
+  oracle_thick_mode:
+    type: select
+    required: false
+    label:
+      en_US: Oracle Thick Mode
+      zh_Hans: Oracle Thick 模式
+      pt_BR: Oracle Thick Mode
+    default: "false"
+    options:
+      - value: "false"
+        label:
+          en_US: Disabled
+          zh_Hans: 关闭
+          pt_BR: Disabled
+      - value: "true"
+        label:
+          en_US: Enabled
+          zh_Hans: 开启
+          pt_BR: Enabled
+
+  oracle_client_lib_dir:
+    type: text-input
+    required: false
+    label:
+      en_US: Oracle Client Lib Dir
+      zh_Hans: Oracle Client 库目录
+      pt_BR: Oracle Client Lib Dir
+    placeholder:
+      en_US: Optional Instant Client library path for Oracle Thick mode.
+      zh_Hans: Oracle Thick 模式可选的 Instant Client 库路径。
+      pt_BR: Optional Instant Client library path for Oracle Thick mode.
+
 
   # build_rag:
   #   type: boolean

--- a/service/database_connection.py
+++ b/service/database_connection.py
@@ -1,0 +1,360 @@
+"""
+数据库连接配置与诊断工具。
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, Optional
+from urllib.parse import quote, quote_plus
+
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import NoSuchModuleError
+
+from utils import normalize_dameng_schema_name, quote_dameng_identifier
+
+
+try:
+    import dmPython  # noqa: F401
+    import dmSQLAlchemy  # noqa: F401
+
+    DAMENG_AVAILABLE = True
+except ImportError:
+    DAMENG_AVAILABLE = False
+
+
+DEFAULT_CONNECT_TIMEOUT = 10
+DEFAULT_QUERY_TIMEOUT = 30
+DEFAULT_POOL_RECYCLE = 3600
+DEFAULT_POOL_TIMEOUT = 30
+
+
+DB_DRIVERS = {
+    "mysql": "mysql+pymysql",
+    "postgresql": "postgresql+psycopg2",
+    "mssql": "mssql+pymssql",
+    "oracle": "oracle+oracledb",
+    "dameng": "dm+dmPython",
+    # Apache Doris 兼容 MySQL 协议，使用内置 MySQL 方言避免缺少 doris 方言插件。
+    "doris": "mysql+pymysql",
+}
+
+
+class DatabaseConnectionError(RuntimeError):
+    """带阶段与处理建议的数据库连接诊断错误。"""
+
+    def __init__(
+        self,
+        stage: str,
+        message: str,
+        suggestion: str,
+        *,
+        original: Optional[BaseException] = None,
+    ):
+        self.stage = stage
+        self.message = message
+        self.suggestion = suggestion
+        self.original = original
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:
+        return (
+            f"{self.stage}失败：{self.message}\n"
+            f"处理建议：{self.suggestion}"
+        )
+
+
+def build_connection_uri(
+    db_type: str,
+    host: str,
+    port: int,
+    user: str,
+    password: str,
+    dbname: str,
+    oracle_connect_type: str = "service_name",
+) -> str:
+    """构建 SQLAlchemy 数据库连接 URI。"""
+    if db_type not in DB_DRIVERS:
+        raise ValueError(f"Unsupported database type: {db_type}")
+
+    encoded_user = quote_plus(user)
+    encoded_password = quote_plus(password)
+    encoded_dbname = quote(str(dbname or ""), safe="")
+    driver = DB_DRIVERS[db_type]
+
+    if db_type == "oracle":
+        connect_type = (oracle_connect_type or "service_name").strip().lower()
+        if connect_type == "sid":
+            sid = quote(str(dbname or ""), safe="")
+            return f"{driver}://{encoded_user}:{encoded_password}@{host}:{port}/{sid}"
+
+        service_name = quote_plus(str(dbname or ""))
+        return (
+            f"{driver}://{encoded_user}:{encoded_password}@{host}:{port}/"
+            f"?service_name={service_name}"
+        )
+
+    if db_type == "dameng":
+        if not DAMENG_AVAILABLE:
+            raise ValueError(
+                "DamengDB support requires dmPython package to be installed"
+            )
+        # dmPython.connect() 不接受 database 参数，schema 通过会话事件切换。
+        return f"{driver}://{encoded_user}:{encoded_password}@{host}:{port}"
+
+    return f"{driver}://{encoded_user}:{encoded_password}@{host}:{port}/{encoded_dbname}"
+
+
+def build_engine_args(
+    db_type: str,
+    oracle_thick_mode: bool = False,
+    oracle_client_lib_dir: Optional[str] = None,
+) -> Dict[str, Any]:
+    """根据数据库类型生成 SQLAlchemy Engine 参数。"""
+    engine_args: Dict[str, Any] = {
+        "pool_pre_ping": True,
+        "pool_recycle": DEFAULT_POOL_RECYCLE,
+        "pool_timeout": DEFAULT_POOL_TIMEOUT,
+        "hide_parameters": True,
+        "echo": False,
+    }
+
+    connect_args: Dict[str, Any] = {}
+
+    if db_type in ["mysql", "doris"]:
+        connect_args.update(
+            {
+                "charset": "utf8mb4",
+                "connect_timeout": DEFAULT_CONNECT_TIMEOUT,
+                "read_timeout": DEFAULT_QUERY_TIMEOUT,
+                "write_timeout": DEFAULT_QUERY_TIMEOUT,
+            }
+        )
+    elif db_type == "postgresql":
+        connect_args.update(
+            {
+                "connect_timeout": DEFAULT_CONNECT_TIMEOUT,
+                "application_name": "schemarag_dify_plugin",
+            }
+        )
+    elif db_type == "mssql":
+        connect_args.update(
+            {
+                "charset": "utf8",
+                "login_timeout": DEFAULT_CONNECT_TIMEOUT,
+                "timeout": DEFAULT_QUERY_TIMEOUT,
+            }
+        )
+    elif db_type == "oracle":
+        connect_args.update(
+            {
+                "thick_mode_dsn_passthrough": False,
+                "tcp_connect_timeout": DEFAULT_CONNECT_TIMEOUT,
+                "retry_count": 1,
+                "retry_delay": 1,
+            }
+        )
+        if oracle_thick_mode:
+            client_lib_dir = (oracle_client_lib_dir or "").strip()
+            engine_args["thick_mode"] = (
+                {"lib_dir": client_lib_dir} if client_lib_dir else True
+            )
+
+    if connect_args:
+        engine_args["connect_args"] = connect_args
+
+    return engine_args
+
+
+def attach_dameng_schema_listener(engine: Engine, dbname: Optional[str]) -> None:
+    """达梦连接建立后切换 CURRENT_SCHEMA。"""
+    normalized_dbname = normalize_dameng_schema_name(dbname)
+    if not normalized_dbname:
+        return
+
+    quoted_dbname = quote_dameng_identifier(normalized_dbname)
+
+    @event.listens_for(engine, "connect")
+    def set_schema(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute(f"ALTER SESSION SET CURRENT_SCHEMA = {quoted_dbname}")
+        cursor.close()
+
+
+def get_connection_test_sql(db_type: str) -> str:
+    """返回连接探测 SQL。"""
+    if db_type == "oracle":
+        return "SELECT 1 FROM DUAL"
+    return "SELECT 1"
+
+
+def format_connection_target(
+    db_type: str,
+    host: Optional[str],
+    port: Optional[int],
+    user: Optional[str],
+    dbname: Optional[str],
+    schema: Optional[str] = None,
+    oracle_connect_type: Optional[str] = None,
+) -> str:
+    """生成不含密码的连接目标描述，便于日志排障。"""
+    target = (
+        f"{db_type}://{user or '<empty>'}@"
+        f"{host or '<empty>'}:{port or '<empty>'}/{dbname or '<empty>'}"
+    )
+    extras = []
+    if schema:
+        extras.append(f"schema={schema}")
+    if db_type == "oracle":
+        extras.append(f"oracle_connect_type={oracle_connect_type or 'service_name'}")
+    if extras:
+        target = f"{target}?{'&'.join(extras)}"
+    return target
+
+
+def sanitize_error_message(
+    error: BaseException,
+    secrets: Optional[Iterable[Optional[str]]] = None,
+) -> str:
+    """清理异常消息中的敏感信息。"""
+    message = str(error)
+    for secret in secrets or []:
+        if secret:
+            message = message.replace(str(secret), "***")
+    message = re.sub(r"://([^:/@\s]+):([^@/\s]+)@", r"://\1:***@", message)
+    return message
+
+
+def diagnose_database_exception(
+    stage: str,
+    db_type: str,
+    error: BaseException,
+    *,
+    target: Optional[str] = None,
+    schema: Optional[str] = None,
+    secrets: Optional[Iterable[Optional[str]]] = None,
+) -> DatabaseConnectionError:
+    """将底层连接/反射异常转换为用户可处理的诊断信息。"""
+    raw_message = sanitize_error_message(error, secrets)
+    message_lower = raw_message.lower()
+    target_text = f"目标 {target}，" if target else ""
+    schema_text = f"schema/owner={schema}，" if schema else ""
+
+    if isinstance(error, NoSuchModuleError) or "can't load plugin" in message_lower:
+        return DatabaseConnectionError(
+            stage,
+            f"{target_text}SQLAlchemy 无法加载 {db_type} 方言或驱动：{raw_message}",
+            "请确认插件运行环境已安装对应驱动；Doris 使用 MySQL 协议时应走 mysql+pymysql，达梦需在 Linux/Windows 环境安装 dmPython 与 dmSQLAlchemy。",
+            original=error,
+        )
+
+    if "dmpython" in message_lower and "requires" in message_lower:
+        return DatabaseConnectionError(
+            stage,
+            f"{target_text}达梦驱动不可用：{raw_message}",
+            "请在 Dify plugin_daemon 对应运行环境安装 dmPython 与 dmSQLAlchemy；macOS 本地调试可跳过达梦依赖或使用 Linux 容器。",
+            original=error,
+        )
+
+    if any(
+        marker in message_lower
+        for marker in [
+            "timed out",
+            "timeout",
+            "connection refused",
+            "could not connect",
+            "can't connect",
+            "no route to host",
+            "name or service not known",
+            "temporary failure in name resolution",
+            "unknown host",
+            "adaptive server is unavailable",
+            "ora-12541",
+            "ora-12545",
+        ]
+    ):
+        return DatabaseConnectionError(
+            stage,
+            f"{target_text}无法建立 TCP/数据库会话：{raw_message}",
+            "请确认主机、端口、防火墙和 Dify plugin_daemon 容器网络可达；本机数据库在 Docker 中通常不能填 127.0.0.1，需要使用可从容器访问的地址。",
+            original=error,
+        )
+
+    if any(
+        marker in message_lower
+        for marker in [
+            "access denied",
+            "password authentication failed",
+            "login failed",
+            "authentication failed",
+            "ora-01017",
+            "用户名",
+            "口令",
+        ]
+    ):
+        return DatabaseConnectionError(
+            stage,
+            f"{target_text}账号认证失败：{raw_message}",
+            "请确认用户名、密码、认证方式和来源 IP 白名单；密码中的 @、#、/、空格等特殊字符需要按表单原文填写，插件会自动 URL 编码。",
+            original=error,
+        )
+
+    if any(
+        marker in message_lower
+        for marker in [
+            "unknown database",
+            "database does not exist",
+            "does not exist",
+            "cannot open database",
+            "ora-12514",
+            "ora-12505",
+            "ora-12154",
+        ]
+    ):
+        return DatabaseConnectionError(
+            stage,
+            f"{target_text}数据库名、服务名或 SID 不匹配：{raw_message}",
+            "请确认 Database Name 的含义：MySQL/PostgreSQL/Doris 为数据库名，Oracle 默认为 service_name，可切换 SID；SQL Server 需确认登录账号有权打开该数据库。",
+            original=error,
+        )
+
+    if any(
+        marker in message_lower
+        for marker in [
+            "permission denied",
+            "insufficient privileges",
+            "not authorized",
+            "select command denied",
+            "ora-01031",
+        ]
+    ):
+        return DatabaseConnectionError(
+            stage,
+            f"{target_text}{schema_text}元数据读取权限不足：{raw_message}",
+            "请给账号授予读取表、列、注释、外键等元数据的权限，至少需要能查看目标 schema 下的表结构并执行轻量只读探测查询。",
+            original=error,
+        )
+
+    if "include_tables" in message_lower or "not found in database" in message_lower:
+        return DatabaseConnectionError(
+            stage,
+            f"{target_text}{schema_text}指定表不存在或当前账号不可见：{raw_message}",
+            "请检查 Tables Name 是否拼写正确、是否需要带大小写引号，或先清空该配置让插件扫描当前 schema 下的可见表。",
+            original=error,
+        )
+
+    if "schema" in message_lower or "current_schema" in message_lower:
+        return DatabaseConnectionError(
+            stage,
+            f"{target_text}{schema_text}schema/owner 配置不可用：{raw_message}",
+            "请确认 Database Schema 是否存在且当前账号有权限；Oracle/达梦未加引号的 schema 会按数据库规则转为大写。",
+            original=error,
+        )
+
+    return DatabaseConnectionError(
+        stage,
+        f"{target_text}{schema_text}{raw_message}",
+        "请根据上面的原始错误检查驱动、网络、账号、数据库名、schema 与表权限；若仍无法定位，请把该阶段日志提供给管理员排查。",
+        original=error,
+    )

--- a/service/database_service.py
+++ b/service/database_service.py
@@ -2,22 +2,18 @@ import os
 import re
 from typing import Dict, List, Tuple, Optional
 import pandas as pd
-from sqlalchemy import create_engine, text, event
+from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError, OperationalError, ProgrammingError
-from urllib.parse import quote, quote_plus
-from utils import normalize_dameng_schema_name, quote_dameng_identifier
-
-# 尝试导入达梦数据库驱动和 SQLAlchemy 方言，如果不存在则忽略
-try:
-    import dmPython
-    # 导入 dmSQLAlchemy 以注册 SQLAlchemy 方言
-    # dmSQLAlchemy 会自动注册 'dm' 方言到 SQLAlchemy
-    import dmSQLAlchemy
-
-    DAMENG_AVAILABLE = True
-except ImportError:
-    DAMENG_AVAILABLE = False
+from service.database_connection import (
+    DB_DRIVERS as DATABASE_DRIVERS,
+    DatabaseConnectionError,
+    attach_dameng_schema_listener,
+    build_connection_uri,
+    build_engine_args,
+    diagnose_database_exception,
+    format_connection_target,
+)
 
 
 class DatabaseService:
@@ -33,14 +29,7 @@ class DatabaseService:
     """
 
     # 数据库驱动映射
-    DB_DRIVERS = {
-        "mysql": "mysql+pymysql",
-        "postgresql": "postgresql+psycopg2",
-        "mssql": "mssql+pymssql",
-        "oracle": "oracle+oracledb",
-        "dameng": "dm+dmPython",  # 达梦数据库
-        "doris": "doris+pymysql",  # Apache Doris (使用 MySQL 协议)
-    }
+    DB_DRIVERS = DATABASE_DRIVERS
 
     def __init__(self):
         """初始化数据库服务"""
@@ -97,39 +86,15 @@ class DatabaseService:
         Raises:
             ValueError: 不支持的数据库类型
         """
-        if db_type not in self.DB_DRIVERS:
-            raise ValueError(f"Unsupported database type: {db_type}")
-
-        # 对密码进行 URL 编码，处理特殊字符
-        encoded_password = quote_plus(password)
-        encoded_user = quote_plus(user)
-
-        driver = self.DB_DRIVERS[db_type]
-
-        # 针对不同数据库类型构建 URI
-        if db_type == "oracle":
-            connect_type = (oracle_connect_type or "service_name").strip().lower()
-            if connect_type == "sid":
-                sid = quote(str(dbname or ""), safe="")
-                return f"{driver}://{encoded_user}:{encoded_password}@{host}:{port}/{sid}"
-
-            # Oracle 默认使用 service_name
-            service_name = quote_plus(str(dbname or ""))
-            return f"{driver}://{encoded_user}:{encoded_password}@{host}:{port}/?service_name={service_name}"
-        elif db_type == "dameng":
-            # 达梦数据库特殊处理
-            if not DAMENG_AVAILABLE:
-                raise ValueError(
-                    "DamengDB support requires dmPython package to be installed"
-                )
-            # 达梦 dmPython.connect() 不接受 'database' 参数，不能在 URI 路径里带 dbname
-            # dbname 会作为 connect_args 单独传入（在 _get_or_create_engine 里处理）
-            return f"{driver}://{encoded_user}:{encoded_password}@{host}:{port}"
-        else:
-            # MySQL, PostgreSQL, MSSQL, Doris 使用标准格式
-            return (
-                f"{driver}://{encoded_user}:{encoded_password}@{host}:{port}/{dbname}"
-            )
+        return build_connection_uri(
+            db_type,
+            host,
+            port,
+            user,
+            password,
+            dbname,
+            oracle_connect_type,
+        )
 
     def _get_or_create_engine(
         self,
@@ -172,44 +137,16 @@ class DatabaseService:
                 db_type, host, port, user, password, dbname, oracle_connect_type
             )
 
-            # 创建引擎配置
-            engine_args = {
-                "pool_pre_ping": True,  # 连接池健康检查
-                "pool_recycle": 3600,  # 连接回收时间（秒）
-                "echo": False,  # 不输出 SQL 日志
-            }
-
-            # 针对特定数据库的额外配置
-            if db_type == "mysql" or db_type == "doris":
-                # MySQL 和 Doris 使用相同的字符集配置
-                engine_args["connect_args"] = {"charset": "utf8mb4"}
-            elif db_type == "mssql":
-                # SQL Server (pymssql) 配置：charset 使用小写 utf8
-                engine_args["connect_args"] = {"charset": "utf8"}
-            elif db_type == "oracle":
-                # Oracle 连接参数：默认 Thin 模式，按配置可切换 Thick 模式
-                engine_args["connect_args"] = {"thick_mode_dsn_passthrough": False}
-                if thick_enabled:
-                    if client_lib_dir:
-                        engine_args["thick_mode"] = {"lib_dir": client_lib_dir}
-                    else:
-                        engine_args["thick_mode"] = True
-            elif db_type == "dameng":
-                # 达梦 dmPython.connect() 只接受 host/port/user/password，不接受 database/encoding
-                # dbname 对应达梦 schema，通过 SQLAlchemy 事件监听器在连接建立后执行切 schema
-                pass
+            engine_args = build_engine_args(
+                db_type,
+                oracle_thick_mode=thick_enabled,
+                oracle_client_lib_dir=client_lib_dir,
+            )
 
             engine = create_engine(uri, **engine_args)
 
             if db_type == "dameng":
-                normalized_dbname = normalize_dameng_schema_name(dbname)
-                quoted_dbname = quote_dameng_identifier(normalized_dbname)
-
-                @event.listens_for(engine, "connect")
-                def set_schema(dbapi_connection, connection_record):
-                    cursor = dbapi_connection.cursor()
-                    cursor.execute(f"ALTER SESSION SET CURRENT_SCHEMA = {quoted_dbname}")
-                    cursor.close()
+                attach_dameng_schema_listener(engine, dbname)
 
             self._engine_cache[cache_key] = engine
 
@@ -257,6 +194,15 @@ class DatabaseService:
         if not cleaned_sql:
             raise ValueError("SQL query cannot be empty.")
 
+        target = format_connection_target(
+            db_type,
+            host,
+            port,
+            user,
+            dbname,
+            oracle_connect_type=oracle_connect_type,
+        )
+
         try:
             # 获取或创建数据库引擎
             engine = self._get_or_create_engine(
@@ -294,9 +240,28 @@ class DatabaseService:
                         "result"
                     ]
 
-        except (OperationalError, ProgrammingError) as e:
-            # 数据库操作错误或 SQL 语法错误
+        except OperationalError as e:
+            # 连接、认证、库名等运行时配置问题需要保留诊断阶段
+            raise diagnose_database_exception(
+                "SQL 执行连接",
+                db_type,
+                e,
+                target=target,
+                secrets=[password],
+            ) from e
+        except ProgrammingError as e:
+            # SQL 语法/对象错误保留为数据库操作错误，便于 SQL Refiner 使用
             raise SQLAlchemyError(f"Database operation failed: {str(e)}") from e
+        except DatabaseConnectionError:
+            raise
+        except ValueError as e:
+            raise diagnose_database_exception(
+                "SQL 执行连接初始化",
+                db_type,
+                e,
+                target=target,
+                secrets=[password],
+            ) from e
         except SQLAlchemyError as e:
             # 其他 SQLAlchemy 错误
             raise SQLAlchemyError(f"SQLAlchemy error: {str(e)}") from e

--- a/service/database_service.py
+++ b/service/database_service.py
@@ -1,10 +1,11 @@
+import os
 import re
 from typing import Dict, List, Tuple, Optional
 import pandas as pd
 from sqlalchemy import create_engine, text, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError, OperationalError, ProgrammingError
-from urllib.parse import quote_plus
+from urllib.parse import quote, quote_plus
 from utils import normalize_dameng_schema_name, quote_dameng_identifier
 
 # 尝试导入达梦数据库驱动和 SQLAlchemy 方言，如果不存在则忽略
@@ -45,8 +46,39 @@ class DatabaseService:
         """初始化数据库服务"""
         self._engine_cache: Dict[str, Engine] = {}
 
+    def _is_oracle_thick_mode_enabled(
+        self, oracle_thick_mode: Optional[bool] = None
+    ) -> bool:
+        """判断是否启用 Oracle Thick 模式。"""
+        if oracle_thick_mode is not None:
+            return oracle_thick_mode
+        return os.environ.get("ORACLE_THICK_MODE", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "y",
+            "on",
+        }
+
+    def _get_oracle_client_lib_dir(
+        self, oracle_client_lib_dir: Optional[str] = None
+    ) -> Optional[str]:
+        """获取 Oracle Client 库路径。"""
+        value = oracle_client_lib_dir or os.environ.get("ORACLE_CLIENT_LIB_DIR")
+        if value is None:
+            return None
+        value = value.strip()
+        return value or None
+
     def _build_connection_uri(
-        self, db_type: str, host: str, port: int, user: str, password: str, dbname: str
+        self,
+        db_type: str,
+        host: str,
+        port: int,
+        user: str,
+        password: str,
+        dbname: str,
+        oracle_connect_type: str = "service_name",
     ) -> str:
         """
         构建 SQLAlchemy 数据库连接 URI
@@ -76,8 +108,14 @@ class DatabaseService:
 
         # 针对不同数据库类型构建 URI
         if db_type == "oracle":
-            # Oracle 使用 service_name
-            return f"{driver}://{encoded_user}:{encoded_password}@{host}:{port}/?service_name={dbname}"
+            connect_type = (oracle_connect_type or "service_name").strip().lower()
+            if connect_type == "sid":
+                sid = quote(str(dbname or ""), safe="")
+                return f"{driver}://{encoded_user}:{encoded_password}@{host}:{port}/{sid}"
+
+            # Oracle 默认使用 service_name
+            service_name = quote_plus(str(dbname or ""))
+            return f"{driver}://{encoded_user}:{encoded_password}@{host}:{port}/?service_name={service_name}"
         elif db_type == "dameng":
             # 达梦数据库特殊处理
             if not DAMENG_AVAILABLE:
@@ -94,7 +132,16 @@ class DatabaseService:
             )
 
     def _get_or_create_engine(
-        self, db_type: str, host: str, port: int, user: str, password: str, dbname: str
+        self,
+        db_type: str,
+        host: str,
+        port: int,
+        user: str,
+        password: str,
+        dbname: str,
+        oracle_connect_type: str = "service_name",
+        oracle_thick_mode: Optional[bool] = None,
+        oracle_client_lib_dir: Optional[str] = None,
     ) -> Engine:
         """
         获取或创建 SQLAlchemy 引擎（带缓存）
@@ -111,11 +158,18 @@ class DatabaseService:
             SQLAlchemy Engine 实例
         """
         # 创建缓存键（不包含密码以提高安全性）
-        cache_key = f"{db_type}://{user}@{host}:{port}/{dbname}"
+        thick_enabled = self._is_oracle_thick_mode_enabled(oracle_thick_mode)
+        client_lib_dir = self._get_oracle_client_lib_dir(oracle_client_lib_dir) or ""
+        cache_key = (
+            f"{db_type}://{user}@{host}:{port}/{dbname}"
+            f"?oracle_connect_type={oracle_connect_type}"
+            f"&oracle_thick_mode={thick_enabled}"
+            f"&oracle_client_lib_dir={client_lib_dir}"
+        )
 
         if cache_key not in self._engine_cache:
             uri = self._build_connection_uri(
-                db_type, host, port, user, password, dbname
+                db_type, host, port, user, password, dbname, oracle_connect_type
             )
 
             # 创建引擎配置
@@ -133,8 +187,13 @@ class DatabaseService:
                 # SQL Server (pymssql) 配置：charset 使用小写 utf8
                 engine_args["connect_args"] = {"charset": "utf8"}
             elif db_type == "oracle":
-                # Oracle 使用 thin 模式，需要在 connect_args 中配置
+                # Oracle 连接参数：默认 Thin 模式，按配置可切换 Thick 模式
                 engine_args["connect_args"] = {"thick_mode_dsn_passthrough": False}
+                if thick_enabled:
+                    if client_lib_dir:
+                        engine_args["thick_mode"] = {"lib_dir": client_lib_dir}
+                    else:
+                        engine_args["thick_mode"] = True
             elif db_type == "dameng":
                 # 达梦 dmPython.connect() 只接受 host/port/user/password，不接受 database/encoding
                 # dbname 对应达梦 schema，通过 SQLAlchemy 事件监听器在连接建立后执行切 schema
@@ -165,6 +224,9 @@ class DatabaseService:
         password: str,
         dbname: str,
         query: str,
+        oracle_connect_type: str = "service_name",
+        oracle_thick_mode: Optional[bool] = None,
+        oracle_client_lib_dir: Optional[str] = None,
     ) -> Tuple[List[Dict], List[str]]:
         """
         使用 SQLAlchemy 连接数据库并执行查询
@@ -198,7 +260,15 @@ class DatabaseService:
         try:
             # 获取或创建数据库引擎
             engine = self._get_or_create_engine(
-                db_type, host, port, user, password, dbname
+                db_type,
+                host,
+                port,
+                user,
+                password,
+                dbname,
+                oracle_connect_type,
+                oracle_thick_mode,
+                oracle_client_lib_dir,
             )
 
             # 使用连接上下文执行查询

--- a/service/knowledge_service.py
+++ b/service/knowledge_service.py
@@ -246,7 +246,7 @@ class KnowledgeService:
         name="schema_cache",
         key_prefix="schema",
         ttl=3600,  # 1小时过期
-        key_generator=lambda self, dataset_id, query, top_k, retrieval_model: 
+        key_generator=lambda self, dataset_id, query, top_k=5, retrieval_model="semantic_search":
             create_cache_key_from_dict(
                 "schema",
                 {

--- a/service/plugin_logging.py
+++ b/service/plugin_logging.py
@@ -1,0 +1,26 @@
+"""
+Dify 插件日志辅助工具。
+"""
+
+import logging
+
+from dify_plugin.config.logger_format import plugin_logger_handler
+
+
+def configure_dify_tcp_logger() -> None:
+    """避免 Dify TCP 写入失败时把内部 BrokenPipe 栈递归写回同一通道。"""
+    tcp_logger = logging.getLogger("dify_plugin.core.server.tcp.request_reader")
+    tcp_logger.propagate = False
+    if not tcp_logger.handlers:
+        tcp_logger.addHandler(logging.NullHandler())
+
+
+def get_plugin_logger(name: str, level: int = logging.INFO) -> logging.Logger:
+    """获取只写 Dify 插件日志通道的 logger，避免重复 handler 和根日志传播。"""
+    configure_dify_tcp_logger()
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    if plugin_logger_handler not in logger.handlers:
+        logger.addHandler(plugin_logger_handler)
+    logger.propagate = False
+    return logger

--- a/service/schema_builder.py
+++ b/service/schema_builder.py
@@ -20,6 +20,7 @@ from service.dify_service import DifyUploader
 from utils import (
     Logger,
     normalize_dameng_schema_name,
+    normalize_oracle_schema_name,
     quote_dameng_identifier,
     read_json,
 )
@@ -92,7 +93,16 @@ class SchemaRAGBuilder:
             # SQL Server (pymssql) 配置：charset 使用小写 utf8
             engine_args["connect_args"] = {"charset": "utf8"}
         elif db_type == "oracle":
+            # Oracle 默认 Thin 模式，按配置可切换 Thick 模式以兼容旧版本服务端
             engine_args["connect_args"] = {"thick_mode_dsn_passthrough": False}
+            if self.db_config.oracle_thick_mode:
+                oracle_client_lib_dir = (
+                    self.db_config.oracle_client_lib_dir or ""
+                ).strip()
+                if oracle_client_lib_dir:
+                    engine_args["thick_mode"] = {"lib_dir": oracle_client_lib_dir}
+                else:
+                    engine_args["thick_mode"] = True
         elif db_type == "dameng":
             # dmPython.connect() 不接受 encoding 参数，达梦 schema 切换由事件监听器处理
             pass
@@ -101,6 +111,31 @@ class SchemaRAGBuilder:
             pass
 
         return engine_args
+
+    def _resolve_schema_name(self) -> Optional[str]:
+        """根据数据库类型解析用于元数据抽取的 schema/owner。"""
+        configured_schema = (self.db_config.schema or "").strip()
+        db_type = self.db_config.type
+
+        if configured_schema:
+            if db_type == "oracle":
+                return normalize_oracle_schema_name(configured_schema)
+            if db_type == "dameng":
+                return normalize_dameng_schema_name(configured_schema)
+            return configured_schema
+
+        if db_type == "oracle":
+            return normalize_oracle_schema_name(self.db_config.user)
+        if db_type == "dameng":
+            return normalize_dameng_schema_name(self.db_config.database)
+        if db_type == "postgresql":
+            return "public"
+        if db_type == "mssql":
+            return "dbo"
+        if db_type in ["mysql", "doris"]:
+            return self.db_config.database
+
+        return None
 
     @staticmethod
     def from_config_file(
@@ -128,6 +163,7 @@ class SchemaRAGBuilder:
         try:
             self.schema_engine = SchemaEngine(
                 engine=self.engine,
+                schema=self._resolve_schema_name(),
                 db_name=self.db_config.database,
                 include_tables=self.include_tables,
             )

--- a/service/schema_builder.py
+++ b/service/schema_builder.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from typing import Optional, List
 import sys
 
@@ -7,7 +8,7 @@ sys.path.append(
 )  # 添加上级目录到路径中
 
 from sqlalchemy.engine import Engine
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine
 from core.m_schema.schema_engine import SchemaEngine
 
 # 尝试导入达梦数据库 SQLAlchemy 方言，如果可用则自动注册
@@ -16,12 +17,21 @@ try:
 except ImportError:
     pass  # 达梦数据库支持可选
 from config import DatabaseConfig, DifyUploadConfig, LoggerConfig
+from service.database_connection import (
+    DatabaseConnectionError,
+    attach_dameng_schema_listener,
+    build_connection_uri,
+    build_engine_args,
+    diagnose_database_exception,
+    format_connection_target,
+    get_connection_test_sql,
+)
 from service.dify_service import DifyUploader
+from service.network_service import NetworkTester
 from utils import (
     Logger,
     normalize_dameng_schema_name,
     normalize_oracle_schema_name,
-    quote_dameng_identifier,
     read_json,
 )
 
@@ -39,6 +49,7 @@ class SchemaRAGBuilder:
         logger_config: LoggerConfig,
         dify_config: Optional[DifyUploadConfig] = None,
         include_tables: Optional[List[str]] = None,
+        logger: Optional[logging.Logger] = None,
     ):
         if not isinstance(db_config, DatabaseConfig):
             raise TypeError("db_config必须为DatabaseConfig类型")
@@ -50,27 +61,71 @@ class SchemaRAGBuilder:
         self.logger_config = logger_config
         self.dify_config = dify_config
         self.include_tables = include_tables
-        self.logger_manager = Logger(self.logger_config)
-        self.logger = self.logger_manager.get_logger()
-        self.engine: Optional[Engine] = create_engine(
-            self.db_config.get_connection_string(),
-            **self._get_engine_args()
-        )
-
-        # 达梦数据库需要在每次连接建立时切换到正确的 schema
-        if self.db_config.type == "dameng":
-            dbname = normalize_dameng_schema_name(self.db_config.database)
-            quoted_dbname = quote_dameng_identifier(dbname)
-
-            @event.listens_for(self.engine, "connect")
-            def set_dameng_schema(dbapi_connection, connection_record):
-                cursor = dbapi_connection.cursor()
-                cursor.execute(f"ALTER SESSION SET CURRENT_SCHEMA = {quoted_dbname}")
-                cursor.close()
-
+        self.logger_manager = None
+        if logger is None:
+            self.logger_manager = Logger(self.logger_config)
+            self.logger = self.logger_manager.get_logger()
+        else:
+            self.logger = logger
+        self.engine: Optional[Engine] = None
         self.uploader: Optional[DifyUploader] = None
         self.schema_engine: Optional[SchemaEngine] = None
+        self._initialize_engine()
         self._initialize_components()
+
+    def _connection_target(self) -> str:
+        """生成不含密码的连接目标描述。"""
+        return format_connection_target(
+            self.db_config.type,
+            self.db_config.host,
+            self.db_config.port,
+            self.db_config.user,
+            self.db_config.database,
+            schema=self._resolve_schema_name(),
+            oracle_connect_type=self.db_config.oracle_connect_type,
+        )
+
+    def _raise_diagnostic_error(
+        self,
+        stage: str,
+        error: BaseException,
+        *,
+        schema: Optional[str] = None,
+    ) -> None:
+        """记录并抛出带处理建议的数据库诊断错误。"""
+        diagnostic = diagnose_database_exception(
+            stage,
+            self.db_config.type,
+            error,
+            target=self._connection_target(),
+            schema=schema,
+            secrets=[self.db_config.password],
+        )
+        self.logger.error(str(diagnostic))
+        raise diagnostic from error
+
+    def _initialize_engine(self) -> None:
+        """创建 SQLAlchemy Engine，但不把懒连接误认为连接成功。"""
+        target = self._connection_target()
+        self.logger.info(f"开始创建数据库引擎: {target}")
+        try:
+            self.engine = create_engine(
+                build_connection_uri(
+                    self.db_config.type,
+                    self.db_config.host,
+                    self.db_config.port,
+                    self.db_config.user,
+                    self.db_config.password,
+                    self.db_config.database,
+                    self.db_config.oracle_connect_type,
+                ),
+                **self._get_engine_args(),
+            )
+            if self.db_config.type == "dameng":
+                attach_dameng_schema_listener(self.engine, self.db_config.database)
+            self.logger.info(f"数据库引擎创建完成: {target}")
+        except Exception as e:
+            self._raise_diagnostic_error("数据库引擎创建", e)
 
     def _get_engine_args(self) -> dict:
         """
@@ -79,38 +134,11 @@ class SchemaRAGBuilder:
         Returns:
             引擎配置参数字典
         """
-        engine_args = {
-            "pool_pre_ping": True,
-            "pool_recycle": 3600,
-            "echo": False,
-        }
-
-        db_type = self.db_config.type
-
-        if db_type == "mysql" or db_type == "doris":
-            engine_args["connect_args"] = {"charset": "utf8mb4"}
-        elif db_type == "mssql":
-            # SQL Server (pymssql) 配置：charset 使用小写 utf8
-            engine_args["connect_args"] = {"charset": "utf8"}
-        elif db_type == "oracle":
-            # Oracle 默认 Thin 模式，按配置可切换 Thick 模式以兼容旧版本服务端
-            engine_args["connect_args"] = {"thick_mode_dsn_passthrough": False}
-            if self.db_config.oracle_thick_mode:
-                oracle_client_lib_dir = (
-                    self.db_config.oracle_client_lib_dir or ""
-                ).strip()
-                if oracle_client_lib_dir:
-                    engine_args["thick_mode"] = {"lib_dir": oracle_client_lib_dir}
-                else:
-                    engine_args["thick_mode"] = True
-        elif db_type == "dameng":
-            # dmPython.connect() 不接受 encoding 参数，达梦 schema 切换由事件监听器处理
-            pass
-        elif db_type == "postgresql":
-            # PostgreSQL 使用 psycopg2，默认支持 UTF-8
-            pass
-
-        return engine_args
+        return build_engine_args(
+            self.db_config.type,
+            oracle_thick_mode=self.db_config.oracle_thick_mode,
+            oracle_client_lib_dir=self.db_config.oracle_client_lib_dir,
+        )
 
     def _resolve_schema_name(self) -> Optional[str]:
         """根据数据库类型解析用于元数据抽取的 schema/owner。"""
@@ -159,18 +187,40 @@ class SchemaRAGBuilder:
         """初始化所有服务组件"""
         if not self.engine:
             self.logger.error("数据库引擎未成功创建，无法初始化Schema引擎")
-            raise RuntimeError("数据库引擎未成功创建，请检查数据库配置")
+            raise DatabaseConnectionError(
+                "数据库引擎创建",
+                "SQLAlchemy Engine 未创建",
+                "请检查数据库类型、驱动依赖和连接配置。",
+            )
+        self._check_network_connectivity()
+        self._verify_database_connection()
+
+        schema_name = self._resolve_schema_name()
         try:
+            self.logger.info(
+                f"开始初始化 Schema 引擎: target={self._connection_target()}"
+            )
             self.schema_engine = SchemaEngine(
                 engine=self.engine,
-                schema=self._resolve_schema_name(),
+                schema=schema_name,
                 db_name=self.db_config.database,
                 include_tables=self.include_tables,
             )
-            self.logger.info("Schema引擎初始化成功")
+            usable_tables = list(self.schema_engine.get_usable_table_names())
+            if not usable_tables:
+                raise DatabaseConnectionError(
+                    "Schema 反射",
+                    f"当前配置下没有可见数据表: {self._connection_target()}",
+                    "请确认 Database Schema 是否正确、账号是否有表结构读取权限；如果只配置了 Tables Name，请先清空后重试确认可见表。",
+                )
+            self.logger.info(
+                f"Schema引擎初始化成功，可见表数量: {len(usable_tables)}"
+            )
+        except DatabaseConnectionError as e:
+            self.logger.error(str(e))
+            raise
         except Exception as e:
-            self.logger.error(f"Schema引擎初始化失败: {e}")
-            raise RuntimeError(f"无法初始化Schema引擎，请检查数据库配置: {e}") from e
+            self._raise_diagnostic_error("Schema 反射", e, schema=schema_name)
         if self.dify_config:
             try:
                 self.uploader = DifyUploader(self.dify_config, self.logger)
@@ -190,9 +240,11 @@ class SchemaRAGBuilder:
         self.logger.info("开始生成数据字典...")
         try:
             mschema = self.schema_engine.mschema
-            if not mschema:
-                self.logger.error("未能获取到数据库schema信息")
-                raise RuntimeError("无法获取数据库schema信息，请检查数据库连接")
+            if not mschema or not mschema.tables:
+                self.logger.error("未能获取到可用数据库schema信息")
+                raise RuntimeError(
+                    "无法获取数据库schema信息：目标 schema 下没有可见表或账号缺少元数据读取权限"
+                )
             mschema_str = mschema.to_mschema()
             # if save_path:
             #     if save_path.endswith(".json"):
@@ -256,3 +308,39 @@ class SchemaRAGBuilder:
         if self.engine:
             self.engine.dispose()
             self.logger.info("数据库连接已关闭")
+
+    def _check_network_connectivity(self) -> None:
+        """在 DBAPI 登录前先检查插件运行环境到数据库端口的 TCP 连通性。"""
+        if self.db_config.type == "sqlite":
+            return
+
+        target = self._connection_target()
+        self.logger.info(f"开始检查数据库网络连通性: {target}")
+        if NetworkTester.test_connectivity(
+            self.db_config.host,
+            self.db_config.port,
+        ):
+            self.logger.info(f"数据库网络连通性检查通过: {target}")
+            return
+
+        diagnostic = DatabaseConnectionError(
+            "网络连通性检查",
+            f"插件运行环境无法连接到 {self.db_config.host}:{self.db_config.port}",
+            "请确认主机、端口、防火墙、安全组和 Dify plugin_daemon 容器网络；如果数据库在宿主机本机，不要在容器中使用 127.0.0.1。",
+        )
+        self.logger.error(str(diagnostic))
+        raise diagnostic
+
+    def _verify_database_connection(self) -> None:
+        """显式打开连接并执行轻量探测 SQL，定位认证与服务名问题。"""
+        if not self.engine:
+            return
+
+        target = self._connection_target()
+        self.logger.info(f"开始验证数据库登录与基础查询: {target}")
+        try:
+            with self.engine.connect() as connection:
+                connection.exec_driver_sql(get_connection_test_sql(self.db_config.type))
+            self.logger.info(f"数据库登录与基础查询验证通过: {target}")
+        except Exception as e:
+            self._raise_diagnostic_error("数据库登录验证", e)

--- a/service/sql_refiner.py
+++ b/service/sql_refiner.py
@@ -156,7 +156,12 @@ class SQLRefiner:
                 user=db_config['user'],
                 password=db_config['password'],
                 dbname=db_config['dbname'],
-                query=validation_sql
+                query=validation_sql,
+                oracle_connect_type=db_config.get(
+                    'oracle_connect_type', 'service_name'
+                ),
+                oracle_thick_mode=db_config.get('oracle_thick_mode'),
+                oracle_client_lib_dir=db_config.get('oracle_client_lib_dir')
             )
             
             return True, ""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,12 @@
+"""
+pytest 全局测试配置
+"""
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/test/test_cache_behavior.py
+++ b/test/test_cache_behavior.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+测试缓存后端、缓存管理器和缓存装饰器
+"""
+
+import pytest
+
+from service.cache.base import CacheManager
+from service.cache.decorators import cacheable, invalidate_cache
+from service.cache.memory import LRUCache, TTLCache
+from service.cache.utils import (
+    batch_normalize_queries,
+    create_cache_key_from_dict,
+    generate_cache_key,
+    is_cache_key_valid,
+    normalize_query,
+    sanitize_cache_key,
+)
+
+
+def test_lru_cache_eviction_expiry_and_cleanup():
+    """LRU 后端应支持容量淘汰、TTL 过期和过期清理。"""
+    cache = LRUCache(max_size=2)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    assert cache.get("a") == 1
+
+    cache.set("c", 3)
+    assert cache.get("b") is None
+    assert cache.get("a") == 1
+    assert cache.get("c") == 3
+
+    cache.set("expired", "value", ttl=0)
+    assert cache.get("expired") is None
+
+    cache.set("expired-1", "value", ttl=0)
+    cache.set("expired-2", "value", ttl=0)
+    assert cache.cleanup_expired() == 2
+
+
+def test_lru_cache_rejects_invalid_max_size():
+    """LRU 后端容量必须为正数。"""
+    with pytest.raises(ValueError, match="max_size必须大于0"):
+        LRUCache(max_size=0)
+
+
+def test_ttl_cache_expiry_eviction_and_stats():
+    """TTL 后端应按过期时间读取，并在满容量时淘汰旧项。"""
+    cache = TTLCache(max_size=2, default_ttl=3600)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+
+    assert cache.get("a") is None
+    assert cache.get("b") == 2
+    assert cache.get("c") == 3
+
+    cache.set("expired", "value", ttl=0)
+    assert cache.get("expired") is None
+
+    stats = cache.get_stats()
+    assert stats["backend_type"] == "ttl_memory"
+    assert stats["max_size"] == 2
+
+
+def test_cache_manager_tracks_hits_misses_and_can_reset_stats():
+    """CacheManager 应统计命中/未命中，并支持重置统计。"""
+    manager = CacheManager("unit-cache-manager")
+    manager.set_backend(LRUCache(max_size=2))
+
+    manager.set("key", "value")
+    assert manager.get("key") == "value"
+    assert manager.get("missing") is None
+
+    stats = manager.get_stats()
+    assert stats["hit_count"] == 1
+    assert stats["miss_count"] == 1
+    assert stats["hit_rate"] == 50.0
+
+    manager.reset_stats()
+    assert manager.get_stats()["total_requests"] == 0
+
+
+def test_cacheable_decorator_caches_results_and_supports_cache_clear():
+    """cacheable 装饰器应缓存结果，并提供 cache_clear 控制。"""
+    calls = {"count": 0}
+
+    @cacheable(name="unit-cacheable", key_prefix="double")
+    def double(value):
+        calls["count"] += 1
+        return value * 2
+
+    double.cache_clear()
+    assert double(3) == 6
+    assert double(3) == 6
+    assert calls["count"] == 1
+
+    double.cache_clear()
+    assert double(3) == 6
+    assert calls["count"] == 2
+
+
+def test_cacheable_condition_and_invalidate_cache():
+    """条件缓存只缓存满足条件的结果，失效装饰器可清空缓存。"""
+    calls = {"count": 0}
+
+    @cacheable(
+        name="unit-conditional-cache",
+        key_prefix="maybe",
+        condition=lambda result: result is not None,
+    )
+    def maybe(value):
+        calls["count"] += 1
+        return value
+
+    @invalidate_cache("unit-conditional-cache")
+    def clear_cache_side_effect():
+        return "ok"
+
+    maybe.cache_clear()
+    assert maybe(None) is None
+    assert maybe(None) is None
+    assert calls["count"] == 2
+
+    assert maybe("cached") == "cached"
+    assert maybe("cached") == "cached"
+    assert calls["count"] == 3
+
+    assert clear_cache_side_effect() == "ok"
+    assert maybe("cached") == "cached"
+    assert calls["count"] == 4
+
+
+def test_cache_key_utilities_are_stable_and_sanitize_long_keys():
+    """缓存键工具应稳定、可规范化并处理超长/非法字符。"""
+    assert normalize_query(" 请 帮我 查询 用户 信息 ") == "用户 信息"
+    assert batch_normalize_queries(["查询 A", "获取 B"]) == ["a", "b"]
+    assert generate_cache_key("prefix", "x", page=1).startswith("prefix:")
+    assert create_cache_key_from_dict("schema", {"b": 2, "a": 1}) == (
+        create_cache_key_from_dict("schema", {"a": 1, "b": 2})
+    )
+
+    sanitized = sanitize_cache_key("bad key/with spaces", max_length=250)
+    assert sanitized == "bad_key_with_spaces"
+
+    long_key = "prefix:" + "x" * 400
+    compact = sanitize_cache_key(long_key, max_length=90)
+    assert len(compact) <= 90
+    assert is_cache_key_valid(compact)
+    assert not is_cache_key_valid(None)
+    assert not is_cache_key_valid([])

--- a/test/test_data_summary_tool.py
+++ b/test/test_data_summary_tool.py
@@ -1,0 +1,106 @@
+"""
+测试数据摘要工具的输入处理与 LLM 调用编排。
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from service.plugin_logging import get_plugin_logger
+from tools.data_summary import DataSummaryTool
+
+
+def _create_tool() -> DataSummaryTool:
+    """创建不依赖 Dify runtime 的工具实例。"""
+    tool = object.__new__(DataSummaryTool)
+    tool.logger = get_plugin_logger("test.data_summary_tool")
+    tool.create_text_message = lambda text=None, **kwargs: text or kwargs.get("text")
+    return tool
+
+
+def _chunk(content: str):
+    """创建流式 LLM chunk 替身。"""
+    return SimpleNamespace(
+        delta=SimpleNamespace(
+            message=SimpleNamespace(content=content),
+        )
+    )
+
+
+def test_data_summary_validates_input_and_formats_json():
+    """输入校验和 JSON 格式化应独立可测。"""
+    tool = _create_tool()
+
+    assert tool._validate_input_data("{}", "分析") == (True, "")
+    assert tool._validate_input_data("", "分析")[1] == "数据内容不能为空"
+    assert tool._validate_input_data("{}", "")[1] == "分析查询不能为空"
+    assert tool._validate_input_data("x", "q", "r" * 2001)[1] == (
+        "自定义规则过长，最大支持 2000 字符"
+    )
+
+    formatted = tool._format_data_content('{"name":"张三","score":95}', "auto")
+    assert '"name": "张三"' in formatted
+    assert '"score": 95' in formatted
+
+    assert tool._format_data_content("  plain text  ", "auto") == "plain text"
+
+
+def test_data_summary_truncates_long_data_with_notice():
+    """长数据应截断并带提示，避免超长 prompt。"""
+    tool = _create_tool()
+
+    truncated, was_truncated = tool._truncate_data_if_needed("x" * 120, max_length=110)
+
+    assert was_truncated is True
+    assert len(truncated) <= 120
+    assert "数据内容过长已被截断" in truncated
+
+
+def test_data_summary_invoke_uses_custom_prompt_and_streams_chunks():
+    """自定义 prompt 应替换变量，并按 LLM 流式 chunk 输出。"""
+    tool = _create_tool()
+    calls = {}
+
+    class FakeLLM:
+        def invoke(self, **kwargs):
+            calls.update(kwargs)
+            return [_chunk("结论"), _chunk("：稳定")]
+
+    tool.session = SimpleNamespace(
+        model=SimpleNamespace(
+            llm=FakeLLM(),
+        )
+    )
+
+    outputs = list(
+        tool._invoke(
+            {
+                "data_content": '{"metric":"ARR","value":123}',
+                "query": "总结指标",
+                "llm": {"provider": "fake"},
+                "user_prompt": "请分析 {{data}} / {{query}}",
+            }
+        )
+    )
+
+    assert outputs == ["结论", "：稳定"]
+    assert calls["model_config"] == {"provider": "fake"}
+    assert calls["stream"] is True
+    user_prompt = calls["prompt_messages"][1].content
+    assert '"metric": "ARR"' in user_prompt
+    assert "总结指标" in user_prompt
+
+
+def test_data_summary_invoke_wraps_validation_errors():
+    """缺少 LLM 配置时应返回工具级可读错误。"""
+    tool = _create_tool()
+
+    with pytest.raises(ValueError, match="数据摘要工具执行失败: 缺少LLM模型配置"):
+        list(
+            tool._invoke(
+                {
+                    "data_content": "[]",
+                    "query": "分析",
+                }
+            )
+        )

--- a/test/test_database_connection.py
+++ b/test/test_database_connection.py
@@ -1,0 +1,135 @@
+"""
+测试数据库连接 URI、引擎参数和错误诊断。
+"""
+
+from sqlalchemy.exc import NoSuchModuleError
+
+from service.database_connection import (
+    DatabaseConnectionError,
+    build_connection_uri,
+    build_engine_args,
+    diagnose_database_exception,
+    format_connection_target,
+    get_connection_test_sql,
+    sanitize_error_message,
+)
+
+
+def test_build_connection_uri_encodes_database_name_and_oracle_modes():
+    """数据库名、Oracle service_name/SID 应按各驱动格式正确编码。"""
+    assert build_connection_uri(
+        "mysql",
+        "db.example",
+        3306,
+        "user",
+        "p@ss",
+        "tenant db",
+    ) == "mysql+pymysql://user:p%40ss@db.example:3306/tenant%20db"
+
+    assert build_connection_uri(
+        "oracle",
+        "oracle.example",
+        1521,
+        "system",
+        "p@ss",
+        "ORCLPDB1",
+    ) == "oracle+oracledb://system:p%40ss@oracle.example:1521/?service_name=ORCLPDB1"
+
+    assert build_connection_uri(
+        "oracle",
+        "oracle.example",
+        1521,
+        "system",
+        "p@ss",
+        "ORCL",
+        "sid",
+    ) == "oracle+oracledb://system:p%40ss@oracle.example:1521/ORCL"
+
+
+def test_build_engine_args_for_major_database_types():
+    """各数据库类型应带上对应驱动的超时/字符集参数。"""
+    mysql_args = build_engine_args("mysql")
+    assert mysql_args["pool_pre_ping"] is True
+    assert mysql_args["hide_parameters"] is True
+    assert mysql_args["connect_args"]["charset"] == "utf8mb4"
+    assert mysql_args["connect_args"]["connect_timeout"] == 10
+
+    pg_args = build_engine_args("postgresql")
+    assert pg_args["connect_args"]["connect_timeout"] == 10
+    assert pg_args["connect_args"]["application_name"] == "schemarag_dify_plugin"
+
+    mssql_args = build_engine_args("mssql")
+    assert mssql_args["connect_args"]["login_timeout"] == 10
+    assert mssql_args["connect_args"]["timeout"] == 30
+
+    oracle_args = build_engine_args(
+        "oracle",
+        oracle_thick_mode=True,
+        oracle_client_lib_dir="/opt/oracle/instantclient",
+    )
+    assert oracle_args["connect_args"]["tcp_connect_timeout"] == 10
+    assert oracle_args["connect_args"]["retry_count"] == 1
+    assert oracle_args["thick_mode"] == {"lib_dir": "/opt/oracle/instantclient"}
+
+
+def test_connection_target_and_probe_sql_are_safe_and_dialect_aware():
+    """日志目标不能包含密码，探测 SQL 应匹配数据库方言。"""
+    target = format_connection_target(
+        "oracle",
+        "oracle.example",
+        1521,
+        "system",
+        "ORCLPDB1",
+        schema="SYSTEM",
+        oracle_connect_type="service_name",
+    )
+
+    assert target == (
+        "oracle://system@oracle.example:1521/ORCLPDB1"
+        "?schema=SYSTEM&oracle_connect_type=service_name"
+    )
+    assert "password" not in target
+    assert get_connection_test_sql("oracle") == "SELECT 1 FROM DUAL"
+    assert get_connection_test_sql("mysql") == "SELECT 1"
+
+
+def test_sanitize_error_message_removes_explicit_and_uri_passwords():
+    """异常消息中不能泄露明文密码或 URI 密码。"""
+    message = sanitize_error_message(
+        Exception("connect mysql://root:p@ss@db/app failed with p@ss"),
+        secrets=["p@ss"],
+    )
+
+    assert "p@ss" not in message
+    assert "***" in message
+
+
+def test_diagnose_database_exception_classifies_common_failures():
+    """常见驱动、网络、权限和 schema 错误应转换为可处理诊断。"""
+    cases = [
+        (
+            NoSuchModuleError("sqlalchemy.dialects:doris.pymysql"),
+            "无法加载 mysql 方言或驱动",
+        ),
+        (Exception("connection refused"), "无法建立 TCP/数据库会话"),
+        (Exception("Access denied for user root"), "账号认证失败"),
+        (Exception("Unknown database app"), "数据库名、服务名或 SID 不匹配"),
+        (Exception("permission denied for schema public"), "元数据读取权限不足"),
+        (Exception("include_tables {'orders'} not found in database"), "指定表不存在"),
+        (Exception("current_schema is invalid"), "schema/owner 配置不可用"),
+    ]
+
+    for error, expected in cases:
+        diagnostic = diagnose_database_exception(
+            "测试阶段",
+            "mysql",
+            error,
+            target="mysql://root@db.example:3306/app",
+            schema="public",
+            secrets=["secret"],
+        )
+
+        assert isinstance(diagnostic, DatabaseConnectionError)
+        assert "测试阶段失败" in str(diagnostic)
+        assert expected in str(diagnostic)
+        assert "处理建议" in str(diagnostic)

--- a/test/test_database_service.py
+++ b/test/test_database_service.py
@@ -7,7 +7,9 @@ import json
 from unittest.mock import patch
 
 import pytest
+from sqlalchemy.exc import OperationalError
 
+from service.database_connection import DatabaseConnectionError
 from service.database_service import DatabaseService
 
 
@@ -127,6 +129,33 @@ def test_execute_query_rejects_empty_sql_after_cleanup():
     get_engine.assert_not_called()
 
 
+def test_execute_query_diagnoses_operational_connection_errors():
+    """执行查询时的连接类 OperationalError 应带阶段和处理建议。"""
+    service = DatabaseService()
+    error = OperationalError(
+        "SELECT 1",
+        {},
+        Exception("Access denied for user root"),
+    )
+
+    with patch.object(service, "_get_or_create_engine", side_effect=error):
+        with pytest.raises(DatabaseConnectionError) as context:
+            service.execute_query(
+                "mysql",
+                "db.example",
+                3306,
+                "root",
+                "password",
+                "app",
+                "SELECT 1",
+            )
+
+    message = str(context.value)
+    assert "SQL 执行连接失败" in message
+    assert "账号认证失败" in message
+    assert "password" not in message
+
+
 def test_build_connection_uri_encodes_user_and_password():
     """连接 URI 应 URL 编码用户名和密码中的特殊字符。"""
     service = DatabaseService()
@@ -156,6 +185,51 @@ def test_build_connection_uri_rejects_unsupported_database_type():
             "password",
             "app",
         )
+
+
+def test_build_connection_uri_uses_mysql_protocol_for_doris():
+    """Doris 通过 MySQL 协议连接，避免依赖不存在的 doris SQLAlchemy 方言。"""
+    uri = DatabaseService()._build_connection_uri(
+        "doris",
+        "doris.example",
+        9030,
+        "root",
+        "p@ss#word",
+        "warehouse",
+    )
+
+    assert uri == (
+        "mysql+pymysql://root:p%40ss%23word@doris.example:9030/warehouse"
+    )
+
+
+def test_get_or_create_engine_uses_reliable_pool_and_timeout_args():
+    """创建引擎时启用连接池健康检查、超时和敏感参数隐藏。"""
+    service = DatabaseService()
+    fake_engine = object()
+
+    with patch(
+        "service.database_service.create_engine",
+        return_value=fake_engine,
+    ) as create_engine:
+        engine = service._get_or_create_engine(
+            "mysql",
+            "db.example",
+            3306,
+            "root",
+            "password",
+            "app",
+        )
+
+    assert engine is fake_engine
+    engine_args = create_engine.call_args.kwargs
+    assert engine_args["pool_pre_ping"] is True
+    assert engine_args["pool_recycle"] == 3600
+    assert engine_args["pool_timeout"] == 30
+    assert engine_args["hide_parameters"] is True
+    assert engine_args["connect_args"]["connect_timeout"] == 10
+    assert engine_args["connect_args"]["read_timeout"] == 30
+    assert engine_args["connect_args"]["write_timeout"] == 30
 
 
 def test_format_output_json_markdown_and_unsupported_format():

--- a/test/test_database_service.py
+++ b/test/test_database_service.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+测试数据库执行服务的 SQL 执行、格式化和 URI 构建行为
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from service.database_service import DatabaseService
+
+
+class FakeResult:
+    """SQLAlchemy Result 测试替身。"""
+
+    def __init__(self, rows=None, columns=None, rowcount=0):
+        self._rows = rows or []
+        self._columns = columns or []
+        self.rowcount = rowcount
+        self.returns_rows = columns is not None
+
+    def keys(self):
+        return self._columns
+
+    def fetchall(self):
+        return self._rows
+
+
+class FakeConnection:
+    """记录 execute 入参的连接替身。"""
+
+    def __init__(self, result):
+        self.result = result
+        self.executed_sql = None
+
+    def execute(self, statement):
+        self.executed_sql = str(statement)
+        return self.result
+
+
+class FakeConnectContext:
+    """engine.connect() 返回的上下文管理器替身。"""
+
+    def __init__(self, connection):
+        self.connection = connection
+
+    def __enter__(self):
+        return self.connection
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakeEngine:
+    """仅实现 connect 的 Engine 替身。"""
+
+    def __init__(self, connection):
+        self.connection = connection
+
+    def connect(self):
+        return FakeConnectContext(self.connection)
+
+
+def test_execute_query_cleans_markdown_and_returns_rows_as_dicts():
+    """execute_query 应清理 markdown SQL，并把行结果转成字典列表。"""
+    service = DatabaseService()
+    connection = FakeConnection(
+        FakeResult(
+            rows=[(1, "Alice"), (2, "Bob")],
+            columns=["id", "name"],
+        )
+    )
+
+    with patch.object(service, "_get_or_create_engine", return_value=FakeEngine(connection)):
+        rows, columns = service.execute_query(
+            "mysql",
+            "localhost",
+            3306,
+            "root",
+            "password",
+            "app",
+            "```sql\nSELECT * FROM users\n```",
+        )
+
+    assert connection.executed_sql == "SELECT * FROM users"
+    assert columns == ["id", "name"]
+    assert rows == [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+
+
+def test_execute_query_returns_rowcount_for_non_select_statements():
+    """无返回行的 SQL 应返回统一 success 结构和影响行数。"""
+    service = DatabaseService()
+    connection = FakeConnection(FakeResult(columns=None, rowcount=3))
+
+    with patch.object(service, "_get_or_create_engine", return_value=FakeEngine(connection)):
+        rows, columns = service.execute_query(
+            "mysql",
+            "localhost",
+            3306,
+            "root",
+            "password",
+            "app",
+            "UPDATE users SET active = 1",
+        )
+
+    assert rows == [{"status": "success", "rows_affected": 3}]
+    assert columns == ["result"]
+
+
+def test_execute_query_rejects_empty_sql_after_cleanup():
+    """空 SQL 应在连接数据库前被拒绝。"""
+    service = DatabaseService()
+
+    with patch.object(service, "_get_or_create_engine") as get_engine:
+        with pytest.raises(ValueError, match="SQL query cannot be empty"):
+            service.execute_query(
+                "mysql",
+                "localhost",
+                3306,
+                "root",
+                "password",
+                "app",
+                "   ",
+            )
+
+    get_engine.assert_not_called()
+
+
+def test_build_connection_uri_encodes_user_and_password():
+    """连接 URI 应 URL 编码用户名和密码中的特殊字符。"""
+    service = DatabaseService()
+
+    uri = service._build_connection_uri(
+        "postgresql",
+        "db.example",
+        5432,
+        "user@tenant",
+        "p@ss#word",
+        "app",
+    )
+
+    assert uri == (
+        "postgresql+psycopg2://user%40tenant:p%40ss%23word@db.example:5432/app"
+    )
+
+
+def test_build_connection_uri_rejects_unsupported_database_type():
+    """不支持的数据库类型应抛出明确错误。"""
+    with pytest.raises(ValueError, match="Unsupported database type: db2"):
+        DatabaseService()._build_connection_uri(
+            "db2",
+            "localhost",
+            50000,
+            "user",
+            "password",
+            "app",
+        )
+
+
+def test_format_output_json_markdown_and_unsupported_format():
+    """结果格式化支持 JSON/Markdown，并对未知格式返回提示。"""
+    service = DatabaseService()
+    rows = [{"id": 1, "name": "张三"}]
+    columns = ["id", "name"]
+
+    json_output = service._format_output(rows, columns, "json")
+    assert json.loads(json_output) == [{"id": 1, "name": "张三"}]
+
+    md_output = service._format_output(rows, columns, "md")
+    assert "张三" in md_output
+    assert "id" in md_output
+
+    assert service._format_output(rows, columns, "csv") == (
+        "Unsupported output format. Please use 'json' or 'md'."
+    )
+
+
+def test_format_output_handles_empty_results():
+    """空结果集应返回明确说明，而不是空字符串。"""
+    assert DatabaseService()._format_output([], ["id"], "json") == (
+        "Query executed successfully, but returned no results."
+    )

--- a/test/test_database_support.py
+++ b/test/test_database_support.py
@@ -126,6 +126,23 @@ def test_oracle_connection_string_can_use_sid():
     )
 
 
+def test_doris_connection_string_uses_mysql_protocol():
+    """Doris 使用 MySQL 协议连接，避免依赖额外 doris 方言。"""
+    db_config = DatabaseConfig(
+        type="doris",
+        host="localhost",
+        port=9030,
+        user="root",
+        password="password",
+        database="warehouse",
+    )
+
+    assert (
+        db_config.get_connection_string()
+        == "mysql+pymysql://root:password@localhost:9030/warehouse"
+    )
+
+
 def test_schema_builder_oracle_thick_mode_engine_args():
     """Oracle Thick 模式通过 SQLAlchemy thick_mode 参数启用"""
     SchemaRAGBuilder = _load_schema_builder_class()
@@ -163,6 +180,22 @@ def test_schema_builder_oracle_defaults_schema_to_login_user():
     )
 
     assert builder._resolve_schema_name() == "U_MAP"
+
+
+def test_schema_builder_dameng_defaults_schema_to_database_name():
+    """达梦未显式配置 schema 时默认使用数据库名并按规则转大写。"""
+    SchemaRAGBuilder = _load_schema_builder_class()
+    builder = object.__new__(SchemaRAGBuilder)
+    builder.db_config = DatabaseConfig(
+        type="dameng",
+        host="localhost",
+        port=5236,
+        user="SYSDBA",
+        password="password",
+        database="app_schema",
+    )
+
+    assert builder._resolve_schema_name() == "APP_SCHEMA"
 
 
 def test_database_service_oracle_sid_connection_uri():

--- a/test/test_database_support.py
+++ b/test/test_database_support.py
@@ -3,13 +3,23 @@
 测试数据库支持配置
 """
 
-import sys
 import os
+import sys
+import importlib
+from unittest.mock import patch
 
 # 添加项目根目录到路径
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from config import DatabaseConfig
+from service.database_service import DatabaseService
+
+
+def _load_schema_builder_class():
+    """加载真实 SchemaRAGBuilder，避开其他测试安装的 import stub。"""
+    sys.modules.pop("service.schema_builder", None)
+    module = importlib.import_module("service.schema_builder")
+    return module.SchemaRAGBuilder
 
 
 def test_database_connections():
@@ -79,6 +89,125 @@ def test_database_connections():
             print(f"❌ {config['type'].upper():>12}: 错误 - {e}")
 
     print("=" * 60)
+
+
+def test_oracle_connection_string_uses_service_name_by_default():
+    """Oracle 默认使用 service_name 连接格式"""
+    db_config = DatabaseConfig(
+        type="oracle",
+        host="localhost",
+        port=1521,
+        user="system",
+        password="password",
+        database="ORCLPDB1",
+    )
+
+    assert (
+        db_config.get_connection_string()
+        == "oracle+oracledb://system:password@localhost:1521/?service_name=ORCLPDB1"
+    )
+
+
+def test_oracle_connection_string_can_use_sid():
+    """Oracle 兼容 SID 连接格式"""
+    db_config = DatabaseConfig(
+        type="oracle",
+        host="localhost",
+        port=1521,
+        user="system",
+        password="password",
+        database="ORCL",
+        oracle_connect_type="sid",
+    )
+
+    assert (
+        db_config.get_connection_string()
+        == "oracle+oracledb://system:password@localhost:1521/ORCL"
+    )
+
+
+def test_schema_builder_oracle_thick_mode_engine_args():
+    """Oracle Thick 模式通过 SQLAlchemy thick_mode 参数启用"""
+    SchemaRAGBuilder = _load_schema_builder_class()
+    builder = object.__new__(SchemaRAGBuilder)
+    builder.db_config = DatabaseConfig(
+        type="oracle",
+        host="localhost",
+        port=1521,
+        user="u_map",
+        password="password",
+        database="mgdb",
+        oracle_thick_mode=True,
+        oracle_client_lib_dir="/opt/oracle/instantclient_19_22",
+    )
+
+    engine_args = builder._get_engine_args()
+
+    assert engine_args["connect_args"]["thick_mode_dsn_passthrough"] is False
+    assert engine_args["thick_mode"] == {
+        "lib_dir": "/opt/oracle/instantclient_19_22"
+    }
+
+
+def test_schema_builder_oracle_defaults_schema_to_login_user():
+    """Oracle 未显式配置 schema 时默认使用登录用户名"""
+    SchemaRAGBuilder = _load_schema_builder_class()
+    builder = object.__new__(SchemaRAGBuilder)
+    builder.db_config = DatabaseConfig(
+        type="oracle",
+        host="localhost",
+        port=1521,
+        user="u_map",
+        password="password",
+        database="mgdb",
+    )
+
+    assert builder._resolve_schema_name() == "U_MAP"
+
+
+def test_database_service_oracle_sid_connection_uri():
+    """运行时 SQL 执行服务兼容 Oracle SID URI。"""
+    service = DatabaseService()
+
+    uri = service._build_connection_uri(
+        "oracle",
+        "localhost",
+        1521,
+        "system",
+        "password",
+        "ORCL",
+        "sid",
+    )
+
+    assert uri == "oracle+oracledb://system:password@localhost:1521/ORCL"
+
+
+def test_database_service_oracle_thick_mode_engine_args():
+    """运行时 SQL 执行服务透传 Oracle Thick 模式参数。"""
+    service = DatabaseService()
+    fake_engine = object()
+
+    with patch(
+        "service.database_service.create_engine",
+        return_value=fake_engine,
+    ) as create_engine:
+        engine = service._get_or_create_engine(
+            "oracle",
+            "localhost",
+            1521,
+            "u_map",
+            "password",
+            "mgdb",
+            oracle_thick_mode=True,
+            oracle_client_lib_dir="/opt/oracle/instantclient_19_22",
+        )
+
+    assert engine is fake_engine
+    engine_args = create_engine.call_args.kwargs
+    assert engine_args["connect_args"]["thick_mode_dsn_passthrough"] is False
+    assert engine_args["thick_mode"] == {
+        "lib_dir": "/opt/oracle/instantclient_19_22"
+    }
 
 
 if __name__ == "__main__":

--- a/test/test_dify_service.py
+++ b/test/test_dify_service.py
@@ -4,7 +4,9 @@
 """
 
 import logging
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -25,6 +27,7 @@ class TestDifyUploader(unittest.TestCase):
         """创建响应 Mock"""
         response = Mock()
         response.json.return_value = data
+        response.raise_for_status.return_value = None
         return response
 
     def _create_uploader(self):
@@ -109,6 +112,80 @@ class TestDifyUploader(unittest.TestCase):
 
         self.assertEqual(dataset_id, "target-id")
         client.create_dataset.assert_called_once()
+
+    @patch("service.dify_service.KnowledgeBaseClient")
+    def test_upload_text_sets_dataset_and_official_process_rule(self, client_class):
+        """上传文本时应设置 dataset_id，并使用 schema 友好的分段规则。"""
+        client = client_class.return_value
+        client.list_datasets.return_value = self._response(
+            {
+                "data": [{"id": "dataset-id", "name": "app_schema"}],
+                "has_more": False,
+            }
+        )
+        client.create_document_by_text.return_value = self._response(
+            {"document": {"id": "doc-id"}}
+        )
+        uploader = self._create_uploader()
+
+        uploader.upload_text("app_schema", "# Table: users")
+
+        self.assertEqual(client.dataset_id, "dataset-id")
+        client.create_document_by_text.assert_called_once()
+        _, kwargs = client.create_document_by_text.call_args
+        self.assertEqual(kwargs["name"], "app_schema")
+        self.assertEqual(kwargs["text"], "# Table: users")
+        self.assertEqual(
+            kwargs["extra_params"]["process_rule"]["rules"]["segmentation"],
+            {"separator": "\n#", "max_tokens": 1000},
+        )
+        self.assertEqual(
+            kwargs["extra_params"]["process_rule"]["mode"],
+            "custom",
+        )
+
+    @patch("service.dify_service.KnowledgeBaseClient")
+    def test_upload_file_skips_missing_or_empty_file(self, client_class):
+        """文件不存在或为空时应跳过上传，不创建知识库文档。"""
+        uploader = self._create_uploader()
+
+        with tempfile.NamedTemporaryFile() as tmp_file:
+            uploader.upload_file(tmp_file.name)
+
+        client = client_class.return_value
+        client.create_document_by_file.assert_not_called()
+        client.create_dataset.assert_not_called()
+
+    @patch("service.dify_service.KnowledgeBaseClient")
+    def test_upload_file_sets_dataset_and_file_process_rule(self, client_class):
+        """上传文件时应使用空行分段规则并设置 dataset_id。"""
+        client = client_class.return_value
+        client.list_datasets.return_value = self._response(
+            {
+                "data": [{"id": "dataset-id", "name": "schema"}],
+                "has_more": False,
+            }
+        )
+        client.create_document_by_file.return_value = self._response(
+            {"document": {"id": "doc-id"}}
+        )
+        uploader = self._create_uploader()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = os.path.join(tmp_dir, "schema.md")
+            with open(file_path, "w", encoding="utf-8") as file:
+                file.write("# Table: users\n")
+
+            uploader.upload_file(file_path)
+
+        self.assertEqual(client.dataset_id, "dataset-id")
+        client.create_document_by_file.assert_called_once()
+        _, kwargs = client.create_document_by_file.call_args
+        self.assertEqual(kwargs["file_path"], file_path)
+        self.assertEqual(
+            kwargs["extra_params"]["process_rule"]["rules"]["segmentation"],
+            {"separator": "\n\n", "max_tokens": 1000},
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_knowledge_service.py
+++ b/test/test_knowledge_service.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+测试 Dify 知识库检索服务
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from service.knowledge_service import KnowledgeService
+
+
+@pytest.fixture(autouse=True)
+def clear_schema_cache():
+    """每个测试前清空 schema 检索缓存，避免跨用例污染。"""
+    KnowledgeService.retrieve_schema_from_dataset.cache_clear()
+    yield
+    KnowledgeService.retrieve_schema_from_dataset.cache_clear()
+
+
+def _response(status_code=200, body=None):
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = body or {}
+    return response
+
+
+def _service():
+    return KnowledgeService("http://dify.example/v1/", "dataset-key")
+
+
+def test_retrieve_schema_from_dataset_posts_expected_payload_and_joins_segments():
+    """主检索路径应构造正确 payload，并拼接 records 中的 segment content。"""
+    response = _response(
+        body={
+            "records": [
+                {"segment": {"content": "table users"}},
+                {"segment": {"content": "table orders"}},
+                {"segment": {}},
+                {},
+            ]
+        }
+    )
+
+    with patch("service.knowledge_service.requests.post", return_value=response) as post:
+        content = _service().retrieve_schema_from_dataset(
+            "dataset-1",
+            "用户表",
+            top_k=3,
+            retrieval_model="hybrid_search",
+        )
+
+    assert content == "table users\\n\\ntable orders"
+    post.assert_called_once()
+    url = post.call_args.args[0]
+    headers = post.call_args.kwargs["headers"]
+    payload = post.call_args.kwargs["json"]
+    assert url == "http://dify.example/v1/datasets/dataset-1/retrieve"
+    assert headers["Authorization"] == "Bearer dataset-key"
+    assert payload["query"] == "用户表"
+    assert payload["retrieval_model"]["top_k"] == 3
+    assert payload["retrieval_model"]["search_method"] == "hybrid_search"
+
+
+def test_retrieve_schema_from_dataset_falls_back_when_retrieve_api_fails():
+    """主检索 API 非 200 时应进入文档片段 fallback。"""
+    service = _service()
+
+    with patch(
+        "service.knowledge_service.requests.post",
+        return_value=_response(status_code=500),
+    ), patch.object(
+        service,
+        "_fallback_retrieve_documents",
+        return_value="fallback content",
+    ) as fallback:
+        content = service.retrieve_schema_from_dataset("dataset-1", "query")
+
+    assert content == "fallback content"
+    fallback.assert_called_once_with("dataset-1")
+
+
+def test_retrieve_schema_from_dataset_uses_cache_for_identical_queries():
+    """相同检索参数应命中缓存，避免重复 HTTP 调用。"""
+    response = _response(body={"records": [{"segment": {"content": "schema"}}]})
+
+    with patch("service.knowledge_service.requests.post", return_value=response) as post:
+        service = _service()
+        first = service.retrieve_schema_from_dataset("dataset-1", "  查询 用户 ")
+        second = service.retrieve_schema_from_dataset("dataset-1", "查询 用户")
+
+    assert first == "schema"
+    assert second == "schema"
+    post.assert_called_once()
+
+
+def test_fallback_retrieve_documents_limits_documents_and_collects_segments():
+    """文档 fallback 只读取前 3 个文档，并拼接片段内容。"""
+    service = _service()
+    documents_response = _response(
+        body={
+            "data": [
+                {"id": "doc-1"},
+                {"id": "doc-2"},
+                {"id": "doc-3"},
+                {"id": "doc-4"},
+                {"name": "missing id"},
+            ]
+        }
+    )
+
+    with patch(
+        "service.knowledge_service.requests.get",
+        return_value=documents_response,
+    ) as get, patch.object(
+        service,
+        "_get_document_segments",
+        side_effect=[["a", "b"], [], ["c"]],
+    ) as get_segments:
+        content = service._fallback_retrieve_documents("dataset-1")
+
+    assert content == "a\\n\\nb\\n\\nc"
+    get.assert_called_once_with(
+        "http://dify.example/v1/datasets/dataset-1/documents",
+        headers={
+            "Authorization": "Bearer dataset-key",
+            "Content-Type": "application/json",
+        },
+        timeout=30,
+    )
+    assert get_segments.call_count == 3
+
+
+def test_get_document_segments_limits_to_first_five_nonempty_segments():
+    """文档片段读取只返回前 5 个非空 content。"""
+    response = _response(
+        body={
+            "data": [
+                {"content": "s1"},
+                {"content": ""},
+                {"content": "s2"},
+                {"content": "s3"},
+                {"content": "s4"},
+                {"content": "s5"},
+                {"content": "s6"},
+            ]
+        }
+    )
+
+    with patch("service.knowledge_service.requests.get", return_value=response):
+        segments = _service()._get_document_segments("dataset-1", "doc-1")
+
+    assert segments == ["s1", "s2", "s3", "s4"]
+
+
+def test_retrieve_schema_from_multiple_datasets_delegates_single_dataset():
+    """单个知识库 ID 走单库检索路径。"""
+    service = _service()
+
+    with patch.object(
+        service,
+        "retrieve_schema_from_dataset",
+        return_value="single schema",
+    ) as retrieve:
+        content = service.retrieve_schema_from_multiple_datasets(
+            " dataset-1 ",
+            "query",
+            top_k=7,
+            retrieval_model="keyword_search",
+        )
+
+    assert content == "single schema"
+    retrieve.assert_called_once_with("dataset-1", "query", 7, "keyword_search")
+
+
+def test_retrieve_schema_from_multiple_datasets_merges_async_results():
+    """多个知识库结果应带来源标题并过滤空内容。"""
+    service = _service()
+
+    async def fake_async(dataset_ids, query, top_k, retrieval_model):
+        assert dataset_ids == ["a", "b", "c"]
+        assert query == "query"
+        assert top_k == 2
+        assert retrieval_model == "semantic_search"
+        return [("a", "schema-a"), ("b", ""), ("c", "schema-c")]
+
+    with patch.object(service, "_retrieve_from_multiple_datasets_async", new=fake_async):
+        content = service.retrieve_schema_from_multiple_datasets(
+            "a, b, c",
+            "query",
+            top_k=2,
+        )
+
+    assert content == "=== 知识库 a ===\\nschema-a\\n\\n=== 知识库 c ===\\nschema-c"
+
+
+def test_retrieve_schema_from_multiple_datasets_falls_back_on_async_failure():
+    """多库异步检索异常时应降级到同步检索。"""
+    service = _service()
+
+    with patch.object(
+        service,
+        "_retrieve_from_multiple_datasets_async",
+        side_effect=RuntimeError("event loop failed"),
+    ), patch.object(
+        service,
+        "_fallback_retrieve_multiple_datasets",
+        return_value="fallback multi",
+    ) as fallback:
+        content = service.retrieve_schema_from_multiple_datasets("a,b", "query")
+
+    assert content == "fallback multi"
+    fallback.assert_called_once_with(["a", "b"], "query", 5, "semantic_search")
+
+
+def test_dataset_info_and_list_datasets_parse_success_and_failure_responses():
+    """数据集信息和列表接口应在成功时解析 JSON，失败时返回空值。"""
+    service = _service()
+
+    with patch(
+        "service.knowledge_service.requests.get",
+        side_effect=[
+            _response(body={"id": "dataset-1"}),
+            _response(status_code=404),
+            _response(body={"data": [{"id": "dataset-1"}]}),
+            _response(status_code=500),
+        ],
+    ):
+        assert service.get_dataset_info("dataset-1") == {"id": "dataset-1"}
+        assert service.get_dataset_info("missing") is None
+        assert service.list_datasets() == [{"id": "dataset-1"}]
+        assert service.list_datasets() == []

--- a/test/test_llm_plot_behavior.py
+++ b/test/test_llm_plot_behavior.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+测试 LLM 绘图模块的数据转换、参数校验和 API 响应处理
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from core.llm_plot.chart_generator import ChartGenerator
+from core.llm_plot.config import ChartConfig
+from core.llm_plot.data_processor import DataProcessor
+from core.llm_plot.models import ChartRecommendation
+from core.llm_plot.validator import ParameterValidator
+
+
+def test_line_data_transform_converts_comma_numbers_and_skips_null_values():
+    """折线图数据转换应处理千分位字符串并跳过空值。"""
+    data = [
+        {"month": "Jan", "amount": "1,200.50"},
+        {"month": "Feb", "amount": None},
+        {"month": None, "amount": 100},
+        {"month": "Mar", "amount": 1500},
+    ]
+
+    result = DataProcessor.transform_data_for_chart(
+        "line",
+        data,
+        x_field="month",
+        y_field="amount",
+    )
+
+    assert result == [
+        {"time": "Jan", "value": 1200.50},
+        {"time": "Mar", "value": 1500.0},
+    ]
+
+
+def test_histogram_data_transform_extracts_numeric_values():
+    """直方图数据转换应提取指定数值字段。"""
+    result = DataProcessor.transform_data_for_chart(
+        "histogram",
+        [{"score": "1,000"}, {"score": 25.5}, {"score": None}],
+        x_field="ignored",
+        y_field="score",
+    )
+
+    assert result == [1000.0, 25.5]
+
+
+def test_pie_data_transform_counts_categories_when_y_field_missing():
+    """饼图未提供 y 字段时应按分类计数。"""
+    result = DataProcessor.transform_data_for_chart(
+        "pie",
+        [
+            {"brand": "A"},
+            {"brand": "A"},
+            {"brand": "B"},
+            {"brand": ""},
+        ],
+        x_field="brand",
+    )
+
+    assert result == [
+        {"category": "A", "value": 2},
+        {"category": "B", "value": 1},
+    ]
+
+
+def test_data_transform_reports_missing_fields_with_available_columns():
+    """字段缺失错误应包含缺失字段和可用字段，便于用户修正。"""
+    with pytest.raises(ValueError) as context:
+        DataProcessor.transform_data_for_chart(
+            "line",
+            [{"month": "Jan", "amount": 1}],
+            x_field="month",
+            y_field="sales",
+        )
+
+    assert "sales" in str(context.value)
+    assert "month, amount" in str(context.value)
+
+
+def test_data_processor_clean_data_and_summary():
+    """数据清洗和摘要应过滤全空记录并保留字段信息。"""
+    cleaned = DataProcessor.clean_data(
+        [
+            {},
+            {"id": None, "name": None},
+            {"id": 1, "name": None},
+        ]
+    )
+
+    assert cleaned == [{"id": 1, "name": None}]
+    assert DataProcessor.get_data_summary(cleaned) == {
+        "record_count": 1,
+        "fields": ["id", "name"],
+        "sample": {"id": 1, "name": None},
+    }
+    assert DataProcessor.get_data_summary([]) == {
+        "record_count": 0,
+        "fields": [],
+        "sample": None,
+    }
+
+
+def test_chart_config_deep_merge_and_template_selection():
+    """图表配置合并应保留基础主题并覆盖模板/自定义字段。"""
+    config = ChartConfig.create_chart_config(
+        "histogram",
+        data=[1, 2, 3],
+        title="分数分布",
+        x_title="分数",
+        y_title="人数",
+        style={"lineWidth": 4},
+        binNumber=6,
+    )
+
+    assert config["type"] == "histogram"
+    assert config["theme"] == "academy"
+    assert config["title"] == "分数分布"
+    assert config["axisXTitle"] == "分数"
+    assert config["axisYTitle"] == "人数"
+    assert config["style"]["backgroundColor"] == "#ffffff"
+    assert config["style"]["lineWidth"] == 4
+    assert config["binNumber"] == 6
+
+
+def test_chart_generator_histogram_config_uses_bounded_bin_count():
+    """直方图配置应根据数据量生成有界 binNumber。"""
+    generator = ChartGenerator()
+    recommendation = ChartRecommendation(
+        chart_type="histogram",
+        x_field="score",
+        y_field="score",
+        title="分数分布",
+        description="数值分布适合直方图",
+    )
+    data = [{"score": value} for value in range(60)]
+
+    config = generator.generate_chart_config(recommendation, data)
+
+    assert config["type"] == "histogram"
+    assert config["binNumber"] == 10
+    assert config["axisXTitle"] == "score区间"
+    assert config["data"] == [float(value) for value in range(60)]
+
+
+def test_parameter_validator_accepts_valid_parameters_and_rejects_bad_inputs():
+    """绘图参数验证应覆盖必填、JSON 格式、图表类型和字段存在性。"""
+    valid_parameters = {
+        "user_question": "画销售趋势",
+        "sql_query": "select month, amount from sales",
+        "data": '[{"month":"Jan","amount":1}]',
+        "llm": {"model": "gpt-test"},
+    }
+
+    ParameterValidator.validate_parameters(valid_parameters)
+    ParameterValidator.validate_chart_type("line")
+    ParameterValidator.validate_field_exists(
+        [{"month": "Jan", "amount": 1}],
+        "amount",
+    )
+
+    with pytest.raises(ValueError, match="参数不能为空: sql_query"):
+        ParameterValidator.validate_parameters(valid_parameters | {"sql_query": None})
+
+    with pytest.raises(ValueError, match="有效的 JSON"):
+        ParameterValidator.validate_data_format("{bad json")
+
+    with pytest.raises(ValueError, match="无效的图表类型"):
+        ParameterValidator.validate_chart_type("scatter")
+
+    with pytest.raises(ValueError, match="字段 'missing' 不存在"):
+        ParameterValidator.validate_field_exists([{"field": 1}], "missing")
+
+
+def test_generate_chart_url_success_and_error_responses():
+    """AntV API 成功响应返回 URL，业务失败响应抛出可读错误。"""
+    generator = ChartGenerator()
+    success = Mock()
+    success.json.return_value = {
+        "success": True,
+        "resultObj": "https://example.com/chart.png",
+    }
+
+    with patch("core.llm_plot.chart_generator.requests.post", return_value=success):
+        assert generator.generate_chart_url({"type": "pie", "data": []}) == (
+            "https://example.com/chart.png"
+        )
+
+    failed = Mock()
+    failed.json.return_value = {
+        "success": False,
+        "errorMessage": "bad chart config",
+    }
+
+    with patch("core.llm_plot.chart_generator.requests.post", return_value=failed):
+        with pytest.raises(ValueError, match="bad chart config"):
+            generator.generate_chart_url({"type": "pie", "data": []})
+
+
+def test_generate_chart_url_handles_timeout_and_missing_result_object():
+    """AntV API 超时和缺少 resultObj 时应抛出明确错误。"""
+    generator = ChartGenerator()
+
+    with patch(
+        "core.llm_plot.chart_generator.requests.post",
+        side_effect=requests.exceptions.Timeout,
+    ):
+        with pytest.raises(ValueError, match="请求 AntV API 超时"):
+            generator.generate_chart_url({"type": "pie", "data": []})
+
+    missing_url = Mock()
+    missing_url.json.return_value = {"success": True}
+
+    with patch("core.llm_plot.chart_generator.requests.post", return_value=missing_url):
+        with pytest.raises(ValueError, match="未找到有效的图表 URL"):
+            generator.generate_chart_url({"type": "pie", "data": []})

--- a/test/test_network_service.py
+++ b/test/test_network_service.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+测试网络连通性检查服务
+"""
+
+import socket
+from unittest.mock import patch
+
+from service.network_service import NetworkTester
+
+
+def test_network_tester_returns_true_when_socket_connects():
+    """socket 连接成功时返回 True，并透传 host/port/timeout。"""
+    with patch("service.network_service.socket.create_connection") as create_connection:
+        assert NetworkTester.test_connectivity("db.example", 5432, timeout=3) is True
+
+    create_connection.assert_called_once_with(("db.example", 5432), timeout=3)
+
+
+def test_network_tester_returns_false_for_timeout_and_socket_errors():
+    """socket 超时或网络错误时返回 False。"""
+    with patch(
+        "service.network_service.socket.create_connection",
+        side_effect=socket.timeout,
+    ):
+        assert NetworkTester.test_connectivity("db.example", 5432) is False
+
+    with patch(
+        "service.network_service.socket.create_connection",
+        side_effect=OSError("connection refused"),
+    ):
+        assert NetworkTester.test_connectivity("db.example", 5432) is False

--- a/test/test_parameter_validator.py
+++ b/test/test_parameter_validator.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+测试工具参数验证与提取逻辑
+"""
+
+import logging
+
+import pytest
+
+from tools.parameter_validator import (
+    validate_and_extract_sql_executer_parameters,
+    validate_and_extract_text2sql_parameters,
+)
+
+
+VALID_TEXT2SQL_PARAMETERS = {
+    "dataset_id": " dataset-1 ",
+    "llm": {"provider": "openai", "model": "gpt-test"},
+    "content": " 查询用户数量 ",
+}
+
+
+def test_text2sql_parameter_extraction_trims_values_and_applies_defaults():
+    """Text2SQL 参数验证应清理空白并应用保守默认值。"""
+    result = validate_and_extract_text2sql_parameters(VALID_TEXT2SQL_PARAMETERS)
+
+    assert result == (
+        "dataset-1",
+        {"provider": "openai", "model": "gpt-test"},
+        "查询用户数量",
+        "mysql",
+        5,
+        "semantic_search",
+        "",
+        "",
+        False,
+        3,
+        False,
+        True,
+    )
+
+
+def test_text2sql_parameter_extraction_converts_optional_boolean_and_integer_values():
+    """Text2SQL 参数验证应转换 select 字符串布尔值和数字字段。"""
+    parameters = VALID_TEXT2SQL_PARAMETERS | {
+        "dialect": "postgresql",
+        "top_k": "12",
+        "retrieval_model": "hybrid_search",
+        "custom_prompt": " use strict SQL ",
+        "example_dataset_id": " example-1 ",
+        "memory_enabled": "true",
+        "memory_window_size": "8",
+        "reset_memory": "yes",
+        "cache_enabled": "0",
+    }
+
+    result = validate_and_extract_text2sql_parameters(parameters)
+
+    assert result[3] == "postgresql"
+    assert result[4] == 12
+    assert result[5] == "hybrid_search"
+    assert result[6] == "use strict SQL"
+    assert result[7] == "example-1"
+    assert result[8] is True
+    assert result[9] == 8
+    assert result[10] is True
+    assert result[11] is False
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"dataset_id": " "}, "缺少知识库ID"),
+        ({"llm": None}, "缺少LLM模型配置"),
+        ({"content": ""}, "缺少问题内容"),
+        ({"dialect": "db2"}, "不支持的数据库方言: db2"),
+        ({"top_k": "0"}, "top_k 必须在 1-50 之间"),
+        ({"top_k": "abc"}, "top_k 必须是有效的整数"),
+        ({"retrieval_model": "vector_only"}, "不支持的检索模型: vector_only"),
+        ({"custom_prompt": 42}, "自定义提示词必须是字符串类型"),
+        ({"example_dataset_id": 42}, "示例知识库ID必须是字符串类型"),
+        ({"memory_window_size": "11"}, "memory_window_size 必须在 1-10 之间"),
+    ],
+)
+def test_text2sql_parameter_validation_errors_are_actionable(override, message):
+    """Text2SQL 参数错误应返回明确、面向用户的错误消息。"""
+    assert validate_and_extract_text2sql_parameters(
+        VALID_TEXT2SQL_PARAMETERS | override
+    ) == message
+
+
+def test_text2sql_parameter_validation_rejects_overlong_content():
+    """问题内容超长时应明确报告限制和当前长度。"""
+    result = validate_and_extract_text2sql_parameters(
+        VALID_TEXT2SQL_PARAMETERS | {"content": "x" * 6},
+        max_content_length=5,
+    )
+
+    assert result == "问题内容过长，最大允许 5 字符，当前 6 字符"
+
+
+def test_sql_executer_parameter_extraction_success_path():
+    """SQL 执行器参数验证应提取 SQL、输出格式和行数限制。"""
+    result = validate_and_extract_sql_executer_parameters(
+        {
+            "sql": " SELECT * FROM users ",
+            "output_format": "md",
+            "max_line": "100",
+        }
+    )
+
+    assert result == ("SELECT * FROM users", "md", 100, None)
+
+
+@pytest.mark.parametrize(
+    ("parameters", "message"),
+    [
+        ({}, "SQL查询不能为空"),
+        ({"sql": "   "}, "SQL查询不能为空"),
+        ({"sql": "select 1", "output_format": "csv"}, "输出格式只支持 'json' 或 'md'"),
+    ],
+)
+def test_sql_executer_parameter_validation_errors(parameters, message):
+    """SQL 执行器必要参数和格式错误应返回统一错误消息。"""
+    assert validate_and_extract_sql_executer_parameters(parameters)[3] == message
+
+
+def test_sql_executer_parameter_invalid_max_line_falls_back_to_default(caplog):
+    """max_line 无效时应回退到默认值并记录警告。"""
+    logger = logging.getLogger("test.sql_executer_parameters")
+
+    with caplog.at_level(logging.WARNING):
+        result = validate_and_extract_sql_executer_parameters(
+            {"sql": "select 1", "max_line": "-1"},
+            default_max_rows=500,
+            logger=logger,
+        )
+
+    assert result == ("select 1", "json", 500, None)
+    assert "max_line参数必须大于0" in caplog.text

--- a/test/test_plugin_logging.py
+++ b/test/test_plugin_logging.py
@@ -1,0 +1,33 @@
+"""
+测试 Dify 插件日志保护配置。
+"""
+
+import logging
+
+from dify_plugin.config.logger_format import plugin_logger_handler
+
+from service.plugin_logging import configure_dify_tcp_logger, get_plugin_logger
+
+
+def test_get_plugin_logger_adds_handler_once_and_disables_propagation():
+    """业务 logger 应只挂一次插件 handler，避免重复写 TCP 通道。"""
+    logger = get_plugin_logger("test.plugin.logger")
+    before_count = logger.handlers.count(plugin_logger_handler)
+
+    same_logger = get_plugin_logger("test.plugin.logger")
+    after_count = same_logger.handlers.count(plugin_logger_handler)
+
+    assert same_logger is logger
+    assert before_count == 1
+    assert after_count == 1
+    assert logger.propagate is False
+
+
+def test_configure_dify_tcp_logger_suppresses_recursive_internal_logging():
+    """Dify TCP writer 内部 BrokenPipe 日志不应再写回同一个 stdout/TCP 通道。"""
+    configure_dify_tcp_logger()
+
+    tcp_logger = logging.getLogger("dify_plugin.core.server.tcp.request_reader")
+
+    assert tcp_logger.propagate is False
+    assert any(isinstance(handler, logging.NullHandler) for handler in tcp_logger.handlers)

--- a/test/test_provider_credentials.py
+++ b/test/test_provider_credentials.py
@@ -117,7 +117,14 @@ class TestProviderCredentials(unittest.TestCase):
         created_configs = []
 
         class FakeSchemaRAGBuilder:
-            def __init__(self, db_config, logger_config, dify_config, include_tables):
+            def __init__(
+                self,
+                db_config,
+                logger_config,
+                dify_config,
+                include_tables,
+                logger=None,
+            ):
                 created_configs.append(db_config)
 
             def generate_dictionary(self):
@@ -150,7 +157,14 @@ class TestProviderCredentials(unittest.TestCase):
         created_configs = []
 
         class FakeSchemaRAGBuilder:
-            def __init__(self, db_config, logger_config, dify_config, include_tables):
+            def __init__(
+                self,
+                db_config,
+                logger_config,
+                dify_config,
+                include_tables,
+                logger=None,
+            ):
                 created_configs.append(db_config)
 
             def generate_dictionary(self):

--- a/test/test_provider_credentials.py
+++ b/test/test_provider_credentials.py
@@ -145,6 +145,49 @@ class TestProviderCredentials(unittest.TestCase):
         self.assertIsInstance(created_configs[0].port, int)
         self.assertEqual(1522, created_configs[0].port)
 
+    def test_build_schema_passes_schema_and_oracle_options(self):
+        """Provider 将可选 schema 与 Oracle 连接参数传给数据库配置"""
+        created_configs = []
+
+        class FakeSchemaRAGBuilder:
+            def __init__(self, db_config, logger_config, dify_config, include_tables):
+                created_configs.append(db_config)
+
+            def generate_dictionary(self):
+                return "# users"
+
+            def upload_text_to_dify(self, dataset_name, schema_content):
+                pass
+
+            def close(self):
+                pass
+
+        credentials = VALID_CREDENTIALS | {
+            "db_type": "oracle",
+            "db_port": "1521",
+            "db_name": "ORCL",
+            "db_schema": "u_map",
+            "oracle_connect_type": "sid",
+            "oracle_thick_mode": "true",
+            "oracle_client_lib_dir": "/opt/oracle/instantclient_19_22",
+        }
+
+        with patch(
+            "provider.build_schema_rag.SchemaRAGBuilder",
+            FakeSchemaRAGBuilder,
+        ):
+            self.provider._build_schema_rag(credentials)
+
+        self.assertEqual(1, len(created_configs))
+        db_config = created_configs[0]
+        self.assertEqual("u_map", db_config.schema)
+        self.assertEqual("sid", db_config.oracle_connect_type)
+        self.assertTrue(db_config.oracle_thick_mode)
+        self.assertEqual(
+            "/opt/oracle/instantclient_19_22",
+            db_config.oracle_client_lib_dir,
+        )
+
     def test_invalid_text_port_raises_validation_error(self):
         """端口不是整数时抛出 Dify 凭据校验异常"""
         credentials = VALID_CREDENTIALS | {"db_port": "not-a-port"}

--- a/test/test_schema_builder_diagnostics.py
+++ b/test/test_schema_builder_diagnostics.py
@@ -1,0 +1,172 @@
+"""
+测试 Schema 构建阶段的数据库连接诊断。
+"""
+
+import importlib
+import logging
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from config import DatabaseConfig, LoggerConfig
+from service.database_connection import DatabaseConnectionError
+
+
+def _load_schema_builder_class():
+    """加载真实 SchemaRAGBuilder，避开 Provider 测试安装的 import stub。"""
+    sys.modules.pop("service.schema_builder", None)
+    module = importlib.import_module("service.schema_builder")
+    return module.SchemaRAGBuilder
+
+
+class FakeConnection:
+    """最小连接替身，用于验证连接探测 SQL。"""
+
+    def __init__(self):
+        self.executed_sql = None
+
+    def exec_driver_sql(self, sql):
+        self.executed_sql = sql
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakeEngine:
+    """最小 Engine 替身。"""
+
+    def __init__(self):
+        self.connection = FakeConnection()
+        self.dialect = SimpleNamespace(name="mysql")
+        self.url = SimpleNamespace(username="root")
+        self.disposed = False
+
+    def connect(self):
+        return self.connection
+
+    def dispose(self):
+        self.disposed = True
+
+
+def _db_config() -> DatabaseConfig:
+    return DatabaseConfig(
+        type="mysql",
+        host="db.example",
+        port=3306,
+        user="root",
+        password="password",
+        database="app",
+    )
+
+
+def test_schema_builder_reports_network_connectivity_stage():
+    """网络不可达时应明确停在网络连通性检查阶段。"""
+    SchemaRAGBuilder = _load_schema_builder_class()
+
+    with patch("service.schema_builder.create_engine", return_value=FakeEngine()):
+        with patch(
+            "service.schema_builder.NetworkTester.test_connectivity",
+            return_value=False,
+        ):
+            with pytest.raises(DatabaseConnectionError) as context:
+                SchemaRAGBuilder(
+                    _db_config(),
+                    LoggerConfig(log_level="INFO"),
+                    logger=logging.getLogger("test.schema_builder.network"),
+                )
+
+    message = str(context.value)
+    assert "网络连通性检查失败" in message
+    assert "db.example:3306" in message
+    assert "plugin_daemon" in message
+
+
+def test_schema_builder_reports_schema_reflection_stage_for_missing_tables():
+    """表名不可见时应明确停在 Schema 反射阶段并给出处理建议。"""
+    SchemaRAGBuilder = _load_schema_builder_class()
+
+    with patch("service.schema_builder.create_engine", return_value=FakeEngine()):
+        with patch(
+            "service.schema_builder.NetworkTester.test_connectivity",
+            return_value=True,
+        ):
+            with patch(
+                "service.schema_builder.SchemaEngine",
+                side_effect=ValueError("include_tables {'orders'} not found in database"),
+            ):
+                with pytest.raises(DatabaseConnectionError) as context:
+                    SchemaRAGBuilder(
+                        _db_config(),
+                        LoggerConfig(log_level="INFO"),
+                        include_tables=["orders"],
+                        logger=logging.getLogger("test.schema_builder.schema"),
+                    )
+
+    message = str(context.value)
+    assert "Schema 反射失败" in message
+    assert "指定表不存在或当前账号不可见" in message
+    assert "Tables Name" in message
+
+
+def test_schema_builder_rejects_empty_visible_tables():
+    """目标 schema 没有可见表时不应生成空数据字典。"""
+    SchemaRAGBuilder = _load_schema_builder_class()
+    fake_schema_engine = SimpleNamespace(get_usable_table_names=lambda: [])
+
+    with patch("service.schema_builder.create_engine", return_value=FakeEngine()):
+        with patch(
+            "service.schema_builder.NetworkTester.test_connectivity",
+            return_value=True,
+        ):
+            with patch(
+                "service.schema_builder.SchemaEngine",
+                return_value=fake_schema_engine,
+            ):
+                with pytest.raises(DatabaseConnectionError) as context:
+                    SchemaRAGBuilder(
+                        _db_config(),
+                        LoggerConfig(log_level="INFO"),
+                        logger=logging.getLogger("test.schema_builder.empty"),
+                    )
+
+    assert "Schema 反射失败" in str(context.value)
+    assert "没有可见数据表" in str(context.value)
+
+
+def test_schema_builder_success_path_verifies_connection_and_generates_dictionary():
+    """正常路径应先执行连接探测，再初始化 SchemaEngine 并生成数据字典。"""
+    SchemaRAGBuilder = _load_schema_builder_class()
+    fake_engine = FakeEngine()
+    fake_mschema = SimpleNamespace(
+        tables={"users": {}},
+        to_mschema=lambda: "【DB_ID】 app\n# Table: users",
+    )
+    fake_schema_engine = SimpleNamespace(
+        get_usable_table_names=lambda: ["users"],
+        mschema=fake_mschema,
+    )
+
+    with patch("service.schema_builder.create_engine", return_value=fake_engine):
+        with patch(
+            "service.schema_builder.NetworkTester.test_connectivity",
+            return_value=True,
+        ) as connectivity:
+            with patch(
+                "service.schema_builder.SchemaEngine",
+                return_value=fake_schema_engine,
+            ) as schema_engine_class:
+                builder = SchemaRAGBuilder(
+                    _db_config(),
+                    LoggerConfig(log_level="INFO"),
+                    logger=logging.getLogger("test.schema_builder.success"),
+                )
+
+    assert fake_engine.connection.executed_sql == "SELECT 1"
+    connectivity.assert_called_once_with("db.example", 3306)
+    schema_engine_class.assert_called_once()
+    assert builder.generate_dictionary() == "【DB_ID】 app\n# Table: users"

--- a/test/test_schema_engine_schema_resolution.py
+++ b/test/test_schema_engine_schema_resolution.py
@@ -94,7 +94,8 @@ class TestSchemaEngineSchemaResolution(unittest.TestCase):
         )
 
         self.assertEqual(["U_MAP"], inspector.table_name_schema_calls)
-        self.assertEqual("U_MAP", metadata.reflect_calls[0]["schema"])
+        self.assertEqual([], metadata.reflect_calls)
+        self.assertEqual([], inspector.has_table_calls)
         self.assertEqual({"T_USER": "U_MAP"}, schema_engine._tables_schemas)
 
     def test_postgresql_defaults_to_public_before_reflection(self):
@@ -106,7 +107,8 @@ class TestSchemaEngineSchemaResolution(unittest.TestCase):
         )
 
         self.assertEqual(["public"], inspector.table_name_schema_calls)
-        self.assertEqual("public", metadata.reflect_calls[0]["schema"])
+        self.assertEqual([], metadata.reflect_calls)
+        self.assertEqual([], inspector.has_table_calls)
         self.assertEqual({"T_USER": "public"}, schema_engine._tables_schemas)
 
     def test_dameng_defaults_to_normalized_database_owner_before_reflection(self):
@@ -118,7 +120,8 @@ class TestSchemaEngineSchemaResolution(unittest.TestCase):
         )
 
         self.assertEqual(["DM_APP"], inspector.table_name_schema_calls)
-        self.assertEqual("DM_APP", metadata.reflect_calls[0]["schema"])
+        self.assertEqual([], metadata.reflect_calls)
+        self.assertEqual([], inspector.has_table_calls)
         self.assertEqual({"T_USER": "DM_APP"}, schema_engine._tables_schemas)
 
     def test_configured_oracle_schema_is_respected(self):
@@ -132,8 +135,48 @@ class TestSchemaEngineSchemaResolution(unittest.TestCase):
         )
 
         self.assertEqual(["REPORTING"], inspector.table_name_schema_calls)
-        self.assertEqual("REPORTING", metadata.reflect_calls[0]["schema"])
+        self.assertEqual([], metadata.reflect_calls)
+        self.assertEqual([], inspector.has_table_calls)
         self.assertEqual({"T_USER": "REPORTING"}, schema_engine._tables_schemas)
+
+    def test_schema_engine_does_not_sample_data_values_by_default(self):
+        """默认只抽取元数据，避免保存配置时扫描大表业务数据。"""
+        inspector = FakeInspector("app")
+        engine = FakeEngine(dialect_name="mysql", username="root")
+        metadata = FakeMetadata()
+
+        inspector.get_table_comment = lambda table_name, schema=None: {"text": ""}
+        inspector.get_pk_constraint = lambda table_name, schema=None: {
+            "constrained_columns": ["id"]
+        }
+        inspector.get_foreign_keys = lambda table_name, schema=None: []
+        inspector.get_columns = lambda table_name, schema=None: [
+            {
+                "name": "id",
+                "type": "INTEGER",
+                "nullable": False,
+                "comment": "",
+            }
+        ]
+
+        with patch("core.m_schema.sql_database.inspect", return_value=inspector):
+            with patch.object(
+                SchemaEngine,
+                "fectch_distinct_values",
+                side_effect=AssertionError("不应默认扫描字段样例值"),
+            ):
+                schema_engine = SchemaEngine(
+                    engine=engine,
+                    schema="app",
+                    metadata=metadata,
+                    db_name="app",
+                )
+
+        self.assertEqual([], metadata.reflect_calls)
+        self.assertEqual(
+            [],
+            schema_engine.mschema.tables["T_USER"]["fields"]["id"]["examples"],
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_schema_engine_schema_resolution.py
+++ b/test/test_schema_engine_schema_resolution.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+测试 SchemaEngine 初始化时的 schema/owner 选择逻辑
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from core.m_schema.m_schema import MSchema
+from core.m_schema.schema_engine import SchemaEngine
+
+
+class FakeEngine:
+    """SchemaEngine 测试用最小 Engine。"""
+
+    def __init__(self, dialect_name: str, username: str = "app_user"):
+        self.dialect = SimpleNamespace(name=dialect_name)
+        self.url = SimpleNamespace(username=username)
+
+
+class FakeMetadata:
+    """记录 reflect 入参，避免访问真实数据库。"""
+
+    def __init__(self):
+        self.tables = {}
+        self.reflect_calls = []
+
+    def reflect(self, **kwargs):
+        self.reflect_calls.append(kwargs)
+
+
+class FakeInspector:
+    """记录 Inspector schema 入参。"""
+
+    def __init__(self, expected_schema: str):
+        self.expected_schema = expected_schema
+        self.table_name_schema_calls = []
+        self.has_table_calls = []
+        self.default_schema_name = expected_schema
+
+    def get_table_names(self, schema=None):
+        self.table_name_schema_calls.append(schema)
+        if schema != self.expected_schema:
+            raise AssertionError(
+                f"expected schema {self.expected_schema!r}, got {schema!r}"
+            )
+        return ["T_USER"]
+
+    def get_view_names(self, schema=None):
+        return []
+
+    def has_table(self, table_name, schema=None):
+        self.has_table_calls.append((table_name, schema))
+        return schema == self.expected_schema
+
+    def get_schema_names(self):
+        raise AssertionError("不应在已知 schema 时扫描所有 schema")
+
+
+class TestSchemaEngineSchemaResolution(unittest.TestCase):
+    """SchemaEngine schema/owner 推导测试。"""
+
+    def _build_schema_engine(
+        self,
+        dialect_name: str,
+        expected_schema: str,
+        db_name: str = "test_db",
+        username: str = "app_user",
+        schema=None,
+    ):
+        inspector = FakeInspector(expected_schema)
+        metadata = FakeMetadata()
+        engine = FakeEngine(dialect_name=dialect_name, username=username)
+
+        with patch("core.m_schema.sql_database.inspect", return_value=inspector):
+            schema_engine = SchemaEngine(
+                engine=engine,
+                schema=schema,
+                metadata=metadata,
+                db_name=db_name,
+                mschema=MSchema(db_id=db_name, schema=expected_schema),
+            )
+
+        return schema_engine, inspector, metadata
+
+    def test_oracle_defaults_to_login_user_schema_before_reflection(self):
+        """Oracle 默认使用登录用户作为 schema，避免扫描系统 schema。"""
+        schema_engine, inspector, metadata = self._build_schema_engine(
+            dialect_name="oracle",
+            expected_schema="U_MAP",
+            username="u_map",
+            db_name="mgdb",
+        )
+
+        self.assertEqual(["U_MAP"], inspector.table_name_schema_calls)
+        self.assertEqual("U_MAP", metadata.reflect_calls[0]["schema"])
+        self.assertEqual({"T_USER": "U_MAP"}, schema_engine._tables_schemas)
+
+    def test_postgresql_defaults_to_public_before_reflection(self):
+        """PostgreSQL 默认使用 public schema。"""
+        schema_engine, inspector, metadata = self._build_schema_engine(
+            dialect_name="postgresql",
+            expected_schema="public",
+            db_name="business_db",
+        )
+
+        self.assertEqual(["public"], inspector.table_name_schema_calls)
+        self.assertEqual("public", metadata.reflect_calls[0]["schema"])
+        self.assertEqual({"T_USER": "public"}, schema_engine._tables_schemas)
+
+    def test_dameng_defaults_to_normalized_database_owner_before_reflection(self):
+        """达梦默认将数据库名规范化为 owner/schema。"""
+        schema_engine, inspector, metadata = self._build_schema_engine(
+            dialect_name="dm",
+            expected_schema="DM_APP",
+            db_name="dm_app",
+        )
+
+        self.assertEqual(["DM_APP"], inspector.table_name_schema_calls)
+        self.assertEqual("DM_APP", metadata.reflect_calls[0]["schema"])
+        self.assertEqual({"T_USER": "DM_APP"}, schema_engine._tables_schemas)
+
+    def test_configured_oracle_schema_is_respected(self):
+        """显式配置 Oracle schema 时优先生效。"""
+        schema_engine, inspector, metadata = self._build_schema_engine(
+            dialect_name="oracle",
+            expected_schema="REPORTING",
+            username="u_map",
+            db_name="mgdb",
+            schema="REPORTING",
+        )
+
+        self.assertEqual(["REPORTING"], inspector.table_name_schema_calls)
+        self.assertEqual("REPORTING", metadata.reflect_calls[0]["schema"])
+        self.assertEqual({"T_USER": "REPORTING"}, schema_engine._tables_schemas)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_sql_executer_tool.py
+++ b/test/test_sql_executer_tool.py
@@ -1,0 +1,107 @@
+"""
+测试 SQL 执行工具的工具层行为。
+"""
+
+import json
+import sys
+
+for module_name in [
+    "dify_plugin",
+    "dify_plugin.config",
+    "dify_plugin.config.logger_format",
+    "dify_plugin.entities",
+    "dify_plugin.entities.tool",
+    "dify_plugin.errors",
+    "dify_plugin.errors.tool",
+    "service.plugin_logging",
+    "tools.sql_executer",
+]:
+    sys.modules.pop(module_name, None)
+
+from service.plugin_logging import get_plugin_logger  # noqa: E402
+from tools.sql_executer import SQLExecuterTool  # noqa: E402
+
+
+class FakeDatabaseService:
+    """数据库服务替身。"""
+
+    def __init__(self):
+        self.calls = []
+
+    def execute_query(self, *args):
+        self.calls.append(args)
+        return (
+            [
+                {"id": 1, "amount": 1.0},
+                {"id": 2, "amount": 2.5},
+                {"id": 3, "amount": 3.25},
+            ],
+            ["id", "amount"],
+        )
+
+    def _format_output(self, results, columns, output_format):
+        assert columns == ["id", "amount"]
+        assert output_format == "json"
+        return json.dumps(results, ensure_ascii=False)
+
+
+def _create_tool(config_validated: bool = True) -> SQLExecuterTool:
+    """创建不依赖 Dify runtime 的工具实例。"""
+    tool = object.__new__(SQLExecuterTool)
+    tool._db_service = FakeDatabaseService()
+    tool._db_config = {
+        "db_type": "mysql",
+        "db_host": "db.example",
+        "db_port": 3306,
+        "db_user": "root",
+        "db_password": "password",
+        "db_name": "app",
+        "oracle_connect_type": "service_name",
+        "oracle_thick_mode": False,
+        "oracle_client_lib_dir": None,
+    }
+    tool._config_validated = config_validated
+    tool.logger = get_plugin_logger("test.sql_executer_tool")
+    tool.create_text_message = lambda text=None, **kwargs: text or kwargs.get("text")
+    return tool
+
+
+def test_sql_executer_tool_returns_message_when_provider_config_invalid():
+    """Provider 数据库配置无效时工具应直接返回用户可读错误。"""
+    tool = _create_tool(config_validated=False)
+
+    outputs = list(tool._invoke({"sql": "SELECT 1"}))
+
+    assert outputs == ["错误: 数据库配置不完整或无效，请检查provider配置"]
+
+
+def test_sql_executer_tool_executes_cleans_truncates_and_formats_results():
+    """工具层应清理 SQL、调用数据库服务、按 max_line 截断并格式化输出。"""
+    tool = _create_tool()
+
+    outputs = list(
+        tool._invoke(
+            {
+                "sql": "```sql\nSELECT * FROM orders\n```",
+                "output_format": "json",
+                "max_line": 2,
+            }
+        )
+    )
+
+    assert len(outputs) == 1
+    rows = json.loads(outputs[0])
+    assert rows == [
+        {"id": "1", "amount": "1"},
+        {"id": "2", "amount": "2.5"},
+    ]
+    call_args = tool._db_service.calls[0]
+    assert call_args[:7] == (
+        "mysql",
+        "db.example",
+        3306,
+        "root",
+        "password",
+        "app",
+        "SELECT * FROM orders",
+    )

--- a/test/test_text2data_tool.py
+++ b/test/test_text2data_tool.py
@@ -1,0 +1,102 @@
+"""
+测试 Text2Data 工具中可隔离的数据摘要输出逻辑。
+"""
+
+import json
+import sys
+from types import SimpleNamespace
+
+for module_name in [
+    "dify_plugin",
+    "dify_plugin.config",
+    "dify_plugin.config.logger_format",
+    "dify_plugin.entities",
+    "dify_plugin.entities.model",
+    "dify_plugin.entities.model.message",
+    "dify_plugin.entities.tool",
+    "dify_plugin.errors",
+    "dify_plugin.errors.tool",
+    "service.plugin_logging",
+]:
+    sys.modules.pop(module_name, None)
+
+from service.plugin_logging import get_plugin_logger  # noqa: E402
+from tools.text2data import Text2DataTool  # noqa: E402
+
+
+class FakeDatabaseService:
+    """格式化输出替身。"""
+
+    def _format_output(self, results, columns, output_format):
+        assert output_format == "json"
+        return json.dumps(results, ensure_ascii=False)
+
+
+def _chunk(content: str):
+    """创建流式 LLM chunk 替身。"""
+    return SimpleNamespace(
+        delta=SimpleNamespace(
+            message=SimpleNamespace(content=content),
+        )
+    )
+
+
+def _create_tool(llm):
+    """创建不依赖 Dify runtime 的 Text2DataTool 实例。"""
+    tool = object.__new__(Text2DataTool)
+    tool.logger = get_plugin_logger("test.text2data_tool")
+    tool.db_service = FakeDatabaseService()
+    tool.session = SimpleNamespace(
+        model=SimpleNamespace(
+            llm=llm,
+        )
+    )
+    tool.create_text_message = lambda text=None, **kwargs: text or kwargs.get("text")
+    return tool
+
+
+def test_text2data_summary_output_streams_llm_summary():
+    """摘要输出模式应把 LLM 流式摘要逐段返回。"""
+    calls = {}
+
+    class FakeLLM:
+        def invoke(self, **kwargs):
+            calls.update(kwargs)
+            return [_chunk("收入"), _chunk("增长")]
+
+    tool = _create_tool(FakeLLM())
+
+    outputs = list(
+        tool._handle_summary_output(
+            [{"month": "2026-06", "revenue": "100"}],
+            ["month", "revenue"],
+            "总结收入",
+            {"provider": "fake"},
+        )
+    )
+
+    assert outputs == ["收入", "增长"]
+    assert calls["model_config"] == {"provider": "fake"}
+    assert calls["stream"] is True
+    assert "总结收入" in calls["prompt_messages"][0].content
+
+
+def test_text2data_summary_output_falls_back_to_json_when_llm_fails():
+    """摘要生成失败时应回退返回 JSON 数据，避免工具无结果。"""
+    class FailingLLM:
+        def invoke(self, **kwargs):
+            raise RuntimeError("llm down")
+
+    tool = _create_tool(FailingLLM())
+
+    outputs = list(
+        tool._handle_summary_output(
+            [{"month": "2026-06", "revenue": "100"}],
+            ["month", "revenue"],
+            "总结收入",
+            {"provider": "fake"},
+        )
+    )
+
+    assert len(outputs) == 1
+    assert json.loads(outputs[0]) == [{"month": "2026-06", "revenue": "100"}]

--- a/test/test_utils_behavior.py
+++ b/test/test_utils_behavior.py
@@ -72,6 +72,8 @@ def test_format_single_value_handles_numeric_edge_cases():
     """数值格式化应避免科学计数法并保留特殊浮点值。"""
     assert format_single_value(10) == "10"
     assert format_single_value(10.0) == "10"
+    assert format_single_value(1234.56789) == "1234.56789"
+    assert format_single_value(1e-7) == "0.0000001"
     assert format_single_value(1234.567, decimal_places=2) == "1234.57"
     assert format_single_value(float("nan")) is None
     assert format_single_value(float("inf")) == "inf"
@@ -83,9 +85,9 @@ def test_format_numeric_values_formats_each_row_without_mutating_input():
     """批量数值格式化应返回新列表，保留非数值字段。"""
     rows = [{"id": 1, "amount": 12.345, "name": "Alice"}]
 
-    formatted = format_numeric_values(rows, decimal_places=1)
+    formatted = format_numeric_values(rows)
 
-    assert formatted == [{"id": "1", "amount": "12.3", "name": "Alice"}]
+    assert formatted == [{"id": "1", "amount": "12.345", "name": "Alice"}]
     assert rows == [{"id": 1, "amount": 12.345, "name": "Alice"}]
 
 

--- a/test/test_utils_behavior.py
+++ b/test/test_utils_behavior.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+测试通用工具函数的安全、格式化和缓存行为
+"""
+
+import decimal
+
+import pytest
+
+from utils import (
+    LRUCache,
+    _clean_and_validate_sql,
+    create_config_hash,
+    examples_to_str,
+    format_numeric_values,
+    format_single_value,
+    normalize_dameng_schema_name,
+    normalize_oracle_schema_name,
+    safe_port_conversion,
+)
+
+
+def test_clean_and_validate_sql_extracts_markdown_and_normalizes_whitespace():
+    """SQL 清洗应提取 markdown 代码块并压缩空白。"""
+    sql = """
+    ```sql
+      SELECT   id,   name
+      FROM users
+      WHERE status = 'active'
+    ```
+    """
+
+    cleaned = _clean_and_validate_sql(sql)
+
+    assert cleaned == "SELECT id, name FROM users WHERE status = 'active'"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "DROP TABLE users",
+        "select * from users; delete from users",
+        "select @@version",
+        "select * from information_schema.processlist",
+        "select * from users into outfile '/tmp/users.csv'",
+    ],
+)
+def test_clean_and_validate_sql_rejects_dangerous_patterns(sql):
+    """SQL 清洗应拒绝危险 DDL/DML、系统变量和敏感系统表访问。"""
+    with pytest.raises(ValueError, match="危险的SQL操作"):
+        _clean_and_validate_sql(sql)
+
+
+def test_clean_and_validate_sql_allows_whitelisted_information_schema_views():
+    """允许访问被白名单放行的 information_schema 元数据视图。"""
+    cleaned = _clean_and_validate_sql(
+        "SELECT column_name FROM information_schema.columns WHERE table_name = 'users'"
+    )
+
+    assert "information_schema.columns" in cleaned
+
+
+def test_safe_port_conversion_handles_valid_invalid_and_missing_values():
+    """端口转换对有效、无效和缺失输入有稳定行为。"""
+    assert safe_port_conversion("5432") == 5432
+    assert safe_port_conversion(1521) == 1521
+    assert safe_port_conversion(None) is None
+    assert safe_port_conversion("not-a-port") is None
+
+
+def test_format_single_value_handles_numeric_edge_cases():
+    """数值格式化应避免科学计数法并保留特殊浮点值。"""
+    assert format_single_value(10) == "10"
+    assert format_single_value(10.0) == "10"
+    assert format_single_value(1234.567, decimal_places=2) == "1234.57"
+    assert format_single_value(float("nan")) is None
+    assert format_single_value(float("inf")) == "inf"
+    assert format_single_value(True) is True
+    assert format_single_value("plain text") == "plain text"
+
+
+def test_format_numeric_values_formats_each_row_without_mutating_input():
+    """批量数值格式化应返回新列表，保留非数值字段。"""
+    rows = [{"id": 1, "amount": 12.345, "name": "Alice"}]
+
+    formatted = format_numeric_values(rows, decimal_places=1)
+
+    assert formatted == [{"id": "1", "amount": "12.3", "name": "Alice"}]
+    assert rows == [{"id": 1, "amount": 12.345, "name": "Alice"}]
+
+
+def test_examples_to_str_filters_private_or_unhelpful_examples():
+    """示例值转换应过滤邮箱、链接，并格式化 Decimal。"""
+    assert examples_to_str(["a@example.com", "safe"]) == []
+    assert examples_to_str(["https://example.com"]) == []
+    assert examples_to_str([decimal.Decimal("3.14"), None, "paid"]) == [
+        "3.14",
+        "paid",
+    ]
+
+
+def test_schema_name_normalization_handles_quoted_and_unquoted_identifiers():
+    """达梦和 Oracle 未加引号标识符转大写，加引号时保留大小写。"""
+    assert normalize_dameng_schema_name(" app ") == "APP"
+    assert normalize_oracle_schema_name(" u_map ") == "U_MAP"
+    assert normalize_oracle_schema_name('"MixedCase"') == "MixedCase"
+    assert normalize_dameng_schema_name('"A""B"') == 'A"B'
+    assert normalize_oracle_schema_name(None) is None
+
+
+def test_create_config_hash_excludes_password_from_cache_key():
+    """数据库配置缓存键不应因为密码变化而改变。"""
+    base_config = {
+        "db_type": "mysql",
+        "db_host": "localhost",
+        "db_port": 3306,
+        "db_name": "sales",
+        "db_user": "root",
+        "db_password": "old-secret",
+    }
+    changed_password = base_config | {"db_password": "new-secret"}
+
+    assert create_config_hash(base_config) == create_config_hash(changed_password)
+
+
+def test_lru_cache_eviction_and_recency_update():
+    """LRU 缓存应淘汰最久未使用项，并在 get 后更新使用顺序。"""
+    cache = LRUCache(max_size=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+
+    assert cache.get("a") == 1
+    cache.put("c", 3)
+
+    assert cache.contains("a")
+    assert not cache.contains("b")
+    assert cache.get("c") == 3
+    assert cache.size() == 2

--- a/tools/data_summary.py
+++ b/tools/data_summary.py
@@ -3,12 +3,11 @@ from typing import Any, Optional
 import sys
 import os
 import json
-import logging
 from prompt.summary_prompt import _data_summary_prompt
+from service.plugin_logging import get_plugin_logger
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin.entities.model.message import SystemPromptMessage, UserPromptMessage
-from dify_plugin.config.logger_format import plugin_logger_handler
 # 添加项目根目录到Python路径，以便导入service模块
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if project_root not in sys.path:
@@ -28,8 +27,7 @@ class DataSummaryTool(Tool):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.logger = logging.getLogger(__name__)
-        self.logger.addHandler(plugin_logger_handler)
+        self.logger = get_plugin_logger(__name__)
 
     def _validate_input_data(
         self, data_content: str, query: str, custom_rules: Optional[str] = None

--- a/tools/sql_executer.py
+++ b/tools/sql_executer.py
@@ -67,11 +67,27 @@ class SQLExecuterTool(Tool):
                 "db_user": credentials.get("db_user"),
                 "db_password": credentials.get("db_password"),
                 "db_name": credentials.get("db_name"),
+                "oracle_connect_type": credentials.get(
+                    "oracle_connect_type", "service_name"
+                ),
+                "oracle_thick_mode": str(
+                    credentials.get("oracle_thick_mode", "false")
+                ).lower()
+                in {"1", "true", "yes", "y", "on"},
+                "oracle_client_lib_dir": credentials.get("oracle_client_lib_dir"),
             }
             
             # 验证配置完整性
+            required_keys = [
+                "db_type",
+                "db_host",
+                "db_port",
+                "db_user",
+                "db_password",
+                "db_name",
+            ]
             self._config_validated = all(
-                value is not None for value in self._db_config.values()
+                self._db_config.get(key) is not None for key in required_keys
             )
 
         except Exception as e:
@@ -150,6 +166,9 @@ class SQLExecuterTool(Tool):
                 self._db_config["db_password"],
                 self._db_config["db_name"],
                 cleaned_sql,
+                self._db_config["oracle_connect_type"],
+                self._db_config["oracle_thick_mode"],
+                self._db_config["oracle_client_lib_dir"],
             )
 
             # 记录执行时间

--- a/tools/sql_executer.py
+++ b/tools/sql_executer.py
@@ -3,7 +3,6 @@ import os
 from collections.abc import Generator
 from typing import Any, Dict, List, Optional
 import re
-import logging
 
 from utils import (
     _clean_and_validate_sql,
@@ -21,7 +20,7 @@ sys.path.append(
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from service.database_service import DatabaseService
-from dify_plugin.config.logger_format import plugin_logger_handler
+from service.plugin_logging import get_plugin_logger
 from tools.parameter_validator import validate_and_extract_sql_executer_parameters
 
 
@@ -50,8 +49,7 @@ class SQLExecuterTool(Tool):
         self._db_service = None
         self._db_config = None
         self._config_validated = False
-        self.logger = logging.getLogger(__name__)
-        self.logger.addHandler(plugin_logger_handler)
+        self.logger = get_plugin_logger(__name__)
 
         # 延迟初始化配置
         self._initialize_config()

--- a/tools/sql_executer_cust.py
+++ b/tools/sql_executer_cust.py
@@ -3,7 +3,6 @@ import os
 from collections.abc import Generator
 from typing import Any, Dict, List, Optional
 import re
-import logging
 from urllib.parse import urlparse
 
 from utils import (
@@ -21,7 +20,7 @@ sys.path.append(
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from service.database_service import DatabaseService
-from dify_plugin.config.logger_format import plugin_logger_handler
+from service.plugin_logging import get_plugin_logger
 from tools.parameter_validator import validate_and_extract_sql_executer_parameters
 
 
@@ -50,8 +49,7 @@ class SQLExecuterTool(Tool):
         self._db_service = None
         self._db_config = None
         self._config_validated = False
-        self.logger = logging.getLogger(__name__)
-        self.logger.addHandler(plugin_logger_handler)
+        self.logger = get_plugin_logger(__name__)
 
     @property
     def db_service(self):

--- a/tools/text2data.py
+++ b/tools/text2data.py
@@ -68,6 +68,13 @@ class Text2DataTool(Tool):
         self.db_user = credentials.get("db_user")
         self.db_password = credentials.get("db_password")
         self.db_name = credentials.get("db_name")
+        self.oracle_connect_type = credentials.get(
+            "oracle_connect_type", "service_name"
+        )
+        self.oracle_thick_mode = str(
+            credentials.get("oracle_thick_mode", "false")
+        ).lower() in {"1", "true", "yes", "y", "on"}
+        self.oracle_client_lib_dir = credentials.get("oracle_client_lib_dir")
 
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         """
@@ -229,8 +236,16 @@ class Text2DataTool(Tool):
             
             try:
                 results, columns = self.db_service.execute_query(
-                    self.db_type, self.db_host, self.db_port,
-                    self.db_user, self.db_password, self.db_name, sql_query
+                    self.db_type,
+                    self.db_host,
+                    self.db_port,
+                    self.db_user,
+                    self.db_password,
+                    self.db_name,
+                    sql_query,
+                    self.oracle_connect_type,
+                    self.oracle_thick_mode,
+                    self.oracle_client_lib_dir,
                 )
                 yield self.create_text_message(text=f"✅ 执行成功\n\n共返回 {len(results)} 行数据\n\n")
                 
@@ -258,7 +273,10 @@ class Text2DataTool(Tool):
                             'port': self.db_port,
                             'user': self.db_user,
                             'password': self.db_password,
-                            'dbname': self.db_name
+                            'dbname': self.db_name,
+                            'oracle_connect_type': self.oracle_connect_type,
+                            'oracle_thick_mode': self.oracle_thick_mode,
+                            'oracle_client_lib_dir': self.oracle_client_lib_dir,
                         }
                         
                         # 执行SQL修复
@@ -281,8 +299,16 @@ class Text2DataTool(Tool):
                             
                             # 使用修复后的SQL重新执行
                             results, columns = self.db_service.execute_query(
-                                self.db_type, self.db_host, self.db_port,
-                                self.db_user, self.db_password, self.db_name, refined_sql
+                                self.db_type,
+                                self.db_host,
+                                self.db_port,
+                                self.db_user,
+                                self.db_password,
+                                self.db_name,
+                                refined_sql,
+                                self.oracle_connect_type,
+                                self.oracle_thick_mode,
+                                self.oracle_client_lib_dir,
                             )
                             
                             # 更新sql_query为修复后的版本（用于后续日志）

--- a/tools/text2data.py
+++ b/tools/text2data.py
@@ -3,15 +3,14 @@ from typing import Any, Optional, List, Dict
 import sys
 import os
 import re
-import logging
 from prompt import text2sql_prompt, summary_prompt
 from service.knowledge_service import KnowledgeService
 from service.database_service import DatabaseService
 from service.sql_refiner import SQLRefiner
+from service.plugin_logging import get_plugin_logger
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin.entities.model.message import SystemPromptMessage, UserPromptMessage
-from dify_plugin.config.logger_format import plugin_logger_handler
 
 from utils import (
     _clean_and_validate_sql,
@@ -52,8 +51,7 @@ class Text2DataTool(Tool):
         self.api_uri = self.runtime.credentials.get("api_uri")
         self.dataset_api_key = self.runtime.credentials.get("dataset_api_key")
         self.knowledge_service = KnowledgeService(self.api_uri, self.dataset_api_key)
-        self.logger = logging.getLogger(__name__)
-        self.logger.addHandler(plugin_logger_handler)
+        self.logger = get_plugin_logger(__name__)
 
         # 初始化数据库服务
         self.db_service = DatabaseService()

--- a/tools/text2sql.py
+++ b/tools/text2sql.py
@@ -7,13 +7,11 @@ from prompt import text2sql_prompt
 from service.knowledge_service import KnowledgeService
 from service.context import ContextManager
 from service.cache import CacheManager, normalize_query, create_cache_key_from_dict, CacheConfig
+from service.plugin_logging import get_plugin_logger
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin.entities.model.message import SystemPromptMessage, UserPromptMessage
 from tools.parameter_validator import validate_and_extract_text2sql_parameters
-
-# 导入 logging 和自定义处理器
-from dify_plugin.config.logger_format import plugin_logger_handler
 
 # 添加项目根目录到Python路径，以便导入service模块
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -40,8 +38,7 @@ class Text2SQLTool(Tool):
         self.dataset_api_key = self.runtime.credentials.get("dataset_api_key")
         self._knowledge_service = None
         self._config_validated = False
-        self.logger = logging.getLogger(__name__)
-        self.logger.addHandler(plugin_logger_handler)
+        self.logger = get_plugin_logger(__name__)
         
         # 初始化上下文管理器
         self._context_manager = ContextManager()
@@ -288,4 +285,3 @@ class Text2SQLTool(Tool):
         except Exception as e:
             self.logger.error(f"SQL生成异常: {str(e)}")
             raise ValueError(f"SQL生成异常: {str(e)}")
-

--- a/utils.py
+++ b/utils.py
@@ -18,7 +18,7 @@ class PerformanceConfig:
     """性能配置类，统一管理性能相关参数"""
 
     QUERY_TIMEOUT = 30  # 查询超时时间（秒）
-    DECIMAL_PLACES = 2  # 小数位数
+    DECIMAL_PLACES = None  # 默认保留数据库返回的浮点精度
     CACHE_MAX_SIZE = 5  # 数据库连接缓存大小
     ENABLE_PERFORMANCE_LOG = True  # 是否启用性能日志
 
@@ -199,12 +199,16 @@ def safe_port_conversion(port_value, logger=None) -> Optional[int]:
         return None
 
 
-def format_numeric_values(results: List[Dict], decimal_places: int = 2, logger=None) -> List[Dict]:
-    """格式化数值，避免科学计数法，保留指定小数位数
+def format_numeric_values(
+    results: List[Dict],
+    decimal_places: Optional[int] = None,
+    logger=None,
+) -> List[Dict]:
+    """格式化数值，避免科学计数法，默认保留数据库返回精度
     
     Args:
         results: 查询结果列表
-        decimal_places: 小数位数，默认为2
+        decimal_places: 可选小数位数；不传时保留原始有效精度
         logger: 可选的日志记录器
         
     Returns:
@@ -225,12 +229,12 @@ def format_numeric_values(results: List[Dict], decimal_places: int = 2, logger=N
     return formatted_results
 
 
-def format_single_value(value, decimal_places: int = 2) -> Any:
+def format_single_value(value, decimal_places: Optional[int] = None) -> Any:
     """格式化单个值，优化性能和逻辑
     
     Args:
         value: 要格式化的值
-        decimal_places: 小数位数，默认为2
+        decimal_places: 可选小数位数；不传时保留原始有效精度
         
     Returns:
         格式化后的值
@@ -261,9 +265,10 @@ def format_single_value(value, decimal_places: int = 2) -> Any:
             # 检查是否为整数值（如 1.0, 2.0）
             if value.is_integer():
                 return str(int(value))  # 1.0 显示为 "1" 而不是 "1.00"
-            else:
+            if decimal_places is not None:
                 # 浮点数保留指定小数位数，避免科学计数法
                 return f"{value:.{decimal_places}f}"
+            return format(decimal.Decimal(str(value)), "f")
 
         # 其他数值类型的安全处理
         return str(value)

--- a/utils.py
+++ b/utils.py
@@ -115,6 +115,21 @@ def normalize_dameng_schema_name(schema_name: Optional[str]) -> Optional[str]:
     return normalized.upper()
 
 
+def normalize_oracle_schema_name(schema_name: Optional[str]) -> Optional[str]:
+    """规范化 Oracle schema/owner 名称，未加引号的标识符按 Oracle 规则转为大写。"""
+    if schema_name is None:
+        return None
+
+    normalized = str(schema_name).strip()
+    if not normalized:
+        return normalized
+
+    if len(normalized) >= 2 and normalized.startswith('"') and normalized.endswith('"'):
+        return normalized[1:-1].replace('""', '"')
+
+    return normalized.upper()
+
+
 def quote_dameng_identifier(identifier: str) -> str:
     """安全地为达梦标识符添加双引号。"""
     return f'"{identifier.replace("\"", "\"\"")}"'


### PR DESCRIPTION
## Summary

- 统一数据库连接 URI、Engine 参数、Oracle Thick Mode、达梦 schema 切换和安全诊断。
- Schema 构建保存时增加网络/登录/反射阶段诊断，并默认不再整库 `MetaData.reflect` 或逐字段扫描业务数据样例，降低大库保存卡住风险。
- Dify 知识库上传流程补充分页查找、409 冲突后重查和官方 hyphenated document endpoint 覆盖测试。
- SQL 结果 float 默认保留数据库返回的有效精度，不再强制两位小数。
- 收敛插件日志 handler，避免重复写入和 Dify TCP 内部日志递归。
- 增加连接、Provider、Dify、Schema 诊断、工具入口和数值格式化回归测试。

## Issue Audit

Closed as fixed by this PR/current code path: #57, #56, #55, #49, #47, #46, #44, #41, #36, #34, #30, #24, #22, #21, #20.

Closed as not planned / external model-runtime issue, not a code fix in this PR: #25.

## Root Causes

- Schema 初始化把懒连接误当成功，失败时只给泛化错误；现在会在网络、登录、Schema 反射阶段分别失败并给出处理建议。
- Oracle Thick Mode 参数传递位置错误会进入 `oracledb.connect()`；现在通过 SQLAlchemy `create_engine(thick_mode=...)` 传入。
- 达梦 URI 携带 database path 和方言/依赖处理不稳定；现在使用 `dm+dmPython://user:pass@host:port` 并通过连接事件切换 `CURRENT_SCHEMA`。
- 大库构建会做整库 metadata reflect 与字段样例值查询；现在默认只抽元数据，不扫描业务数据。
- float 输出默认固定两位小数；现在默认保留有效精度。

## Validation

- `uv run --no-sync pytest test/` -> 164 passed
- `git diff --check` -> passed

Note: local `.venv` emitted a Python patch-version warning during tests; tests still passed.
